### PR TITLE
Add builtin extension "APG_ImYourCFGNow"

### DIFF
--- a/extensions-builtin/reForge-APGIsYourCFG/APGIsYourCFG/nodes_APGImYourCFGNow.py
+++ b/extensions-builtin/reForge-APGIsYourCFG/APGIsYourCFG/nodes_APGImYourCFGNow.py
@@ -1,0 +1,136 @@
+from ldm_patched.modules.model_patcher import ModelPatcher
+import torch
+
+
+class MomentumBuffer:
+    def __init__(self, momentum: float):
+        self.momentum = momentum
+        self.running_average = 0
+
+    def update(self, update_value: torch.Tensor):
+        new_average = self.momentum * self.running_average
+        self.running_average = update_value + new_average
+
+
+def project(
+    v0: torch.Tensor,
+    v1: torch.Tensor,
+):
+    dtype = v0.dtype
+    # v0, v1 = v0.double(), v1.double()
+    v1 = torch.nn.functional.normalize(v1, dim=[-1, -2, -3])
+    v0_parallel = (v0 * v1).sum(dim=[-1, -2, -3], keepdim=True) * v1
+    v0_orthogonal = v0 - v0_parallel
+    return v0_parallel.to(dtype), v0_orthogonal.to(dtype)
+
+
+def normalized_guidance(
+    pred_cond: torch.Tensor,
+    pred_uncond: torch.Tensor,
+    guidance_scale: float,
+    momentum_buffer: MomentumBuffer = None,
+    eta: float = 1.0,
+    norm_threshold: float = 0.0,
+):
+    diff = pred_cond - pred_uncond
+    if momentum_buffer is not None:
+        momentum_buffer.update(diff)
+        diff = momentum_buffer.running_average
+    if norm_threshold > 0:
+        ones = torch.ones_like(diff)
+        diff_norm = diff.norm(p=2, dim=[-1, -2, -3], keepdim=True)
+        scale_factor = torch.minimum(ones, norm_threshold / diff_norm)
+        diff = diff * scale_factor
+    diff_parallel, diff_orthogonal = project(diff, pred_cond)
+    normalized_update = diff_orthogonal + eta * diff_parallel
+    pred_guided = pred_cond + (guidance_scale - 1) * normalized_update
+
+    return pred_guided
+
+
+class APG_ImYourCFGNow:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "model": ("MODEL",),
+                "scale": (
+                    "FLOAT",
+                    {
+                        "default": 9.0,
+                        "min": 0.0,
+                        "max": 100.0,
+                        "step": 0.1,
+                        "round": 0.01,
+                    },
+                ),
+                "momentum": (
+                    "FLOAT",
+                    {
+                        "default": -0.05,
+                        "min": -1.5,
+                        "max": 0.5,
+                        "step": 0.01,
+                        "round": 0.001,
+                    },
+                ),
+                "norm_threshold": (
+                    "FLOAT",
+                    {
+                        "default": 15.0,
+                        "min": 0.0,
+                        "max": 50.0,
+                        "step": 0.5,
+                        "round": 0.01,
+                    },
+                ),
+                "eta": (
+                    "FLOAT",
+                    {
+                        "default": 1.0,
+                        "min": 0.0,
+                        "max": 1.0,
+                        "step": 0.1,
+                        "round": 0.01,
+                    },
+                ),
+            },
+        }
+
+    RETURN_TYPES = ("MODEL",)
+    FUNCTION = "patch"
+
+    CATEGORY = "model_patches/unet"
+
+    def patch(
+        self,
+        model: ModelPatcher,
+        scale: float = 9.0,
+        momentum: float = -0.05,
+        norm_threshold: float = 15.0,
+        eta: float = 1.0,
+    ):
+        momentum_buffer = MomentumBuffer(momentum)
+
+        def apg_function(args):
+            cond = args["cond"]
+            uncond = args["uncond"]
+            sigma = args["sigma"]
+            model = args["model"]
+
+            if model.model_sampling.timestep(sigma)[0].item() == 999:
+                momentum_buffer.running_average = 0
+
+            return normalized_guidance(
+                cond, uncond, scale, momentum_buffer, eta, norm_threshold
+            )
+
+        m = model.clone()
+        m.set_model_sampler_cfg_function(apg_function, momentum_buffer)
+
+        return (m,)
+
+
+NODE_CLASS_MAPPINGS = {
+    "APG_ImYourCFGNow": APG_ImYourCFGNow,
+}

--- a/extensions-builtin/reForge-APGIsYourCFG/scripts/advanced_model_sampling_script.py
+++ b/extensions-builtin/reForge-APGIsYourCFG/scripts/advanced_model_sampling_script.py
@@ -1,0 +1,99 @@
+import logging
+import gradio as gr
+from modules import scripts
+from APGIsYourCFG.nodes_APGImYourCFGNow import APG_ImYourCFGNow
+
+
+class APGIsNowYourCFGScript(scripts.Script):
+    def __init__(self):
+        self.enabled = False
+        self.apg_scale = 9.0
+        self.apg_moment = -0.05
+        self.apg_norm_thr = 15.0
+        self.apg_eta = 1.0
+
+    sorting_priority = 15
+
+    def title(self):
+        return '"APG\'s now your CFG" for reForge'
+
+    def show(self, is_img2img):
+        return scripts.AlwaysVisible
+
+    def ui(self, *args, **kwargs):
+        with gr.Accordion(open=False, label=self.title()):
+            gr.HTML("<p><i>Adjust the settings for APG's now your CFG.</i></p>")
+            enabled = gr.Checkbox(label="Enable APG's now your CFG", value=self.enabled)
+            apg_scale = gr.Slider(
+                label="APG Scale",
+                minimum=0.0,
+                maximum=100.0,
+                step=0.1,
+                value=self.apg_scale,
+            )
+            apg_momentum = gr.Slider(
+                label="APG Momentum",
+                minimum=-1.5,
+                maximum=0.5,
+                step=0.01,
+                value=self.apg_moment,
+            )
+            apg_norm_thr = gr.Slider(
+                label="APG Norm Threshold",
+                minimum=0.5,
+                maximum=50.0,
+                step=0.5,
+                value=self.apg_norm_thr,
+            )
+            apg_eta = gr.Slider(
+                label="APG Eta", minimum=0.0, maximum=1.0, step=0.1, value=self.apg_eta
+            )
+
+        enabled.change(lambda x: self.update_enabled(x), inputs=[enabled])
+
+        return (enabled, apg_scale, apg_momentum, apg_norm_thr, apg_eta)
+
+    def update_enabled(self, value):
+        self.enabled = value
+
+    def process_before_every_sampling(self, p, *args, **kwargs):
+        if len(args) >= 5:
+            (
+                self.enabled,
+                self.apg_scale,
+                self.apg_moment,
+                self.apg_norm_thr,
+                self.apg_eta,
+            ) = args[:5]
+        else:
+            logging.warning(
+                "Not enough arguments provided to process_before_every_sampling"
+            )
+            return
+
+        # Always start with a fresh clone of the original unet
+        unet = p.sd_model.forge_objects.unet.clone()
+
+        if not self.enabled:
+            # Reset the unet to its original state
+            p.sd_model.forge_objects.unet = unet
+            return
+
+        unet = APG_ImYourCFGNow().patch(
+            unet, self.apg_scale, self.apg_moment, self.apg_norm_thr, self.apg_eta
+        )[0]
+
+        p.sd_model.forge_objects.unet = unet
+        args = {
+            "apgisyourcfg_enabled": True,
+            "apgisyourcfg_scale": self.apg_scale,
+            "apgisyourcfg_momentum": self.apg_moment,
+            "apgisyourcfg_norm_thr": self.apg_norm_thr,
+            "apgisyourcfg_eta": self.apg_eta,
+        }
+        p.extra_generation_params.update(args)
+        str_args:str = ", ".join([f"{k}:\"{v}\"" for k,v in args.items()])
+        logging.debug("WOLOLO: \"APG is now your CFG!\"")
+        logging.debug(str_args)
+
+        return


### PR DESCRIPTION
# The APG has wololo'd into your CFG!

## Description

* This implementation is based off from here https://github.com/MythicalChu/ComfyUI-APG_ImYourCFGNow
* Most of the node code is exactly the same from MythicalChu. Bless his soul.
* Only stuff I did is hook up the code to the extensions by referencing from rescaleCFG extension

## Screenshots/videos:

**APG (Default Settings)**

![image](https://github.com/user-attachments/assets/844da3bf-ed18-4475-8cc8-004cde574ad9)

**CFG (CFG 7, Defaults)**

![image](https://github.com/user-attachments/assets/32d78d3d-1378-416e-b86e-aadc0462b02b)

Notes about screenshot:

- adetailer was used in the original and the APG version to give a more accurate of "What you can expect".
- Consider experimenting with the 4 sliders. I believe the defaults are for **SDXL**. Which may not be so great for _SD 1.5 models._

## Misc

when writing out to a png file, the following args are included:
```py
args = {
    "apgisyourcfg_enabled": True,
    "apgisyourcfg_scale": self.apg_scale,
    "apgisyourcfg_momentum": self.apg_moment,
    "apgisyourcfg_norm_thr": self.apg_norm_thr,
    "apgisyourcfg_eta": self.apg_eta,
}
```

If debug logging is enabled, you will see a `WOLOLO: \"APG is now your CFG!\"`. This is normal.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
