### PR TITLE
Fix NameError when using ControlNet

### DIFF
--- a/modules_forge/supported_controlnet.py
+++ b/modules_forge/supported_controlnet.py
@@ -99,12 +99,12 @@ class ControlNetPatcher(ControlModelPatcher):
             return ControlNetPatcher(net)
 
         if controlnet_config is None:
-            unet_dtype = ldm_patched.modules.model_management.unet_dtype()
-            controlnet_config = ldm_patched.modules.model_detection.model_config_from_unet(controlnet_data, prefix, True).unet_config
+            unet_dtype = model_management.unet_dtype()
+            controlnet_config = model_detection.model_config_from_unet(controlnet_data, prefix, True).unet_config
             controlnet_config['dtype'] = unet_dtype
 
-        load_device = ldm_patched.modules.model_management.get_torch_device()
-        manual_cast_dtype = ldm_patched.modules.model_management.unet_manual_cast(unet_dtype, load_device)
+        load_device = model_management.get_torch_device()
+        manual_cast_dtype = model_management.unet_manual_cast(unet_dtype, load_device)
         if manual_cast_dtype is not None:
             controlnet_config["operations"] = manual_cast
 


### PR DESCRIPTION
## Description

Fix for the following error

`NameError: name 'ldm_patched' is not defined
`

when using ControlNet, which caused ControlNet to error out and not do anything when generating images.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
The tests seem broken in general, cannot load the test model
