### PR TITLE
Fix vanilla ztSNR option

### DIFF
--- a/extensions-builtin/reForge-advanced_model_sampling/scripts/advanced_model_sampling_script.py
+++ b/extensions-builtin/reForge-advanced_model_sampling/scripts/advanced_model_sampling_script.py
@@ -1,6 +1,7 @@
 import logging
 import gradio as gr
 from modules import scripts
+from modules.shared import opts
 from ldm_patched.modules import model_sampling
 from advanced_model_sampling.nodes_model_advanced import (
     ModelSamplingDiscrete, ModelSamplingContinuousEDM, ModelSamplingContinuousV,
@@ -119,6 +120,8 @@ class AdvancedModelSamplingScript(scripts.Script):
         unet = p.sd_model.forge_objects.unet.clone()
 
         if self.sampling_mode == "Discrete":
+            if self.discrete_zsnr and opts.sd_noise_schedule == "Zero Terminal SNR":  # Do not apply twice
+                self.discrete_zsnr = False
             unet = ModelSamplingDiscrete().patch(unet, self.discrete_sampling, self.discrete_zsnr)[0]
         elif self.sampling_mode == "Continuous EDM":
             unet = ModelSamplingContinuousEDM().patch(unet, self.continuous_edm_sampling, self.continuous_edm_sigma_max, self.continuous_edm_sigma_min)[0]


### PR DESCRIPTION
Title. Mimics the patch made in https://github.com/lllyasviel/stable-diffusion-webui-forge/pull/2119

I am certain this is the correct implementation, however reForge seems to have a very odd seed issue for v-pred models, where my results do not match A1111, upstream Forge, or ComfyUI, _unless_ I set my RNG mode to GPU and do not enable ztSNR. There is otherwise always a mismatch in results. So, despite me not being able to compare my result to other UIs, this patch is certainly not the cause, as it happens even without it.