### PR TITLE
Automatically enable ztSNR when applicable

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -962,7 +962,7 @@ if opts.sd_processing == "reForge OG":
                 sd_models.apply_alpha_schedule_override(p.sd_model, p)
 
                 sigmas_backup = None
-                if opts.sd_noise_schedule == "Zero Terminal SNR" and p is not None:
+                if (opts.sd_noise_schedule == "Zero Terminal SNR" or (hasattr(p.sd_model, 'ztsnr') and p.sd_model.ztsnr)) and p is not None:
                     p.extra_generation_params['Noise Schedule'] = opts.sd_noise_schedule
                     sigmas_backup = p.sd_model.forge_objects.unet.model.model_sampling.sigmas
                     p.sd_model.forge_objects.unet.model.model_sampling.set_sigmas(rescale_zero_terminal_snr_sigmas(p.sd_model.forge_objects.unet.model.model_sampling.sigmas))
@@ -2803,7 +2803,7 @@ elif opts.sd_processing == "reForge A1111":
                 sd_models.apply_alpha_schedule_override(p.sd_model, p)
 
                 sigmas_backup = None
-                if opts.sd_noise_schedule == "Zero Terminal SNR" and p is not None:
+                if (opts.sd_noise_schedule == "Zero Terminal SNR" or (hasattr(p.sd_model, 'ztsnr') and p.sd_model.ztsnr)) and p is not None:
                     p.extra_generation_params['Noise Schedule'] = opts.sd_noise_schedule
                     sigmas_backup = p.sd_model.forge_objects.unet.model.model_sampling.sigmas
                     p.sd_model.forge_objects.unet.model.model_sampling.set_sigmas(rescale_zero_terminal_snr_sigmas(p.sd_model.forge_objects.unet.model.model_sampling.sigmas))

--- a/modules_forge/forge_loader.py
+++ b/modules_forge/forge_loader.py
@@ -171,6 +171,7 @@ def load_state_dict_guess_config(sd, output_vae=True, output_clip=True, output_c
 @torch.no_grad()
 def load_model_for_a1111(timer, checkpoint_info=None, state_dict=None):
     is_sd3 = 'model.diffusion_model.x_embedder.proj.weight' in state_dict
+    ztsnr = 'ztsnr' in state_dict
     timer.record("forge solving config")
     
     if not is_sd3:
@@ -258,6 +259,8 @@ def load_model_for_a1111(timer, checkpoint_info=None, state_dict=None):
     if getattr(sd_model, 'parameterization', None) == 'v':
         sd_model.forge_objects.unet.model.model_sampling = model_sampling(sd_model.forge_objects.unet.model.model_config, ModelType.V_PREDICTION)
     
+    sd_model.ztsnr = ztsnr
+
     sd_model.is_sd3 = is_sd3
     sd_model.latent_channels = 16 if is_sd3 else 4
     sd_model.is_sdxl = conditioner is not None and not is_sd3


### PR DESCRIPTION
## Description

Title. Follow-up to https://github.com/Panchovix/stable-diffusion-webui-reForge/pull/149.

Marking as a draft for now since this may be handled differently.

Related:
https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/16569
https://github.com/lllyasviel/stable-diffusion-webui-forge/pull/2122