### PR TITLE
Attempt to fix seed reproducability issue

### DIFF
--- a/ldm_patched/modules/supported_models.py
+++ b/ldm_patched/modules/supported_models.py
@@ -219,6 +219,8 @@ class SDXL(supported_models_base.BASE):
 
         state_dict = utils.state_dict_key_replace(state_dict, keys_to_replace)
         state_dict = utils.clip_text_transformers_convert(state_dict, "clip_g.", "clip_g.transformer.")
+        if 'clip_g.text_projection' not in state_dict and 'clip_g.transformer.text_projection.weight' in state_dict:
+            state_dict["clip_g.text_projection"] = state_dict.pop("clip_g.transformer.text_projection.weight").transpose(0, 1)
         return state_dict
 
     def process_clip_state_dict_for_saving(self, state_dict):


### PR DESCRIPTION
Fixes issue that arises in 58883a8cb4e7ba02e8c8618b6060a481286240ee (the prior commit 50e80181c3426aa59418973af376a7daf0df289a works fine).

This fix, however, breaks when ztSNR is enabled, whether by the vanilla settings toggle, or the extension. Still unsure what the root cause is. Commits before this, such as 8cfb093fafc677bbe54407fa12cadb00ab32b8ed, may be related.

When the state of ztSNR affecting this is resolved, which will likely coincide with finding the root cause, this should have a compatibility option added and only then be merged.