### PR TITLE
Properly index and apply compiled conditions

### DIFF
--- a/modules/prompt_parser.py
+++ b/modules/prompt_parser.py
@@ -347,7 +347,7 @@ def reconstruct_multicond_batch(c: MulticondLearnedConditioning, current_step):
                     target_index = current
                     break
 
-            conds_for_batch.append((len(tensors), composable_prompt.weight))
+            conds_for_batch.append((len(conds_list), composable_prompt.weight))
             tensors.append(composable_prompt.schedules[target_index].cond)
 
         conds_list.append(conds_for_batch)

--- a/modules/sd_samplers_cfg_denoiser.py
+++ b/modules/sd_samplers_cfg_denoiser.py
@@ -62,7 +62,7 @@ if opts.sd_sampler_cfg_denoiser == "reForge":
             denoised = torch.clone(denoised_uncond)
             for i, conds in enumerate(conds_list):
                 for cond_index, weight in conds:
-                    denoised[i] += (x_out[cond_index] - denoised_uncond[i]) * (weight * cond_scale)
+                    denoised[i] += (x_out[cond_index] - denoised_uncond[i]) * (weight * cond_scale) / len(conds)
             return denoised
 
         def combine_denoised_for_edit_model(self, x_out, cond_scale):


### PR DESCRIPTION
## Description

When using `AND` in prompts, it fails to index the conditions properly and crashes, this fixes that.
Described further in Bug #152.

## Checklist:

- [X] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [X] I have performed a self-review of my own code
- [X] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)

Unusure how to get tests to run, they seem to be referencing a lot of things that seem to be missing? (simple Error 404, not actual bugs).