### PR TITLE
Fix noise combining

### DIFF
--- a/modules/prompt_parser.py
+++ b/modules/prompt_parser.py
@@ -347,7 +347,7 @@ def reconstruct_multicond_batch(c: MulticondLearnedConditioning, current_step):
                     target_index = current
                     break
 
-            conds_for_batch.append((len(conds_list), composable_prompt.weight))
+            conds_for_batch.append((len(conds_for_batch), composable_prompt.weight))
             tensors.append(composable_prompt.schedules[target_index].cond)
 
         conds_list.append(conds_for_batch)

--- a/modules/sd_samplers_cfg_denoiser.py
+++ b/modules/sd_samplers_cfg_denoiser.py
@@ -66,7 +66,7 @@ if opts.sd_sampler_cfg_denoiser == "reForge":
                     avg_weight += weight / len(conds)
                 denoised[i] += (x_out[i] - denoised_uncond[i]) * (avg_weight * cond_scale)
             return denoised
-        
+
         def combine_denoised_for_edit_model(self, x_out, cond_scale):
             out_cond, out_img_cond, out_uncond = x_out.chunk(3)
             denoised = out_uncond + cond_scale * (out_cond - out_img_cond) + self.image_cfg_scale * (out_img_cond - out_uncond)

--- a/modules/sd_samplers_cfg_denoiser.py
+++ b/modules/sd_samplers_cfg_denoiser.py
@@ -61,10 +61,12 @@ if opts.sd_sampler_cfg_denoiser == "reForge":
             denoised_uncond = x_out[-uncond.shape[0]:]
             denoised = torch.clone(denoised_uncond)
             for i, conds in enumerate(conds_list):
-                for cond_index, weight in conds:
-                    denoised[i] += (x_out[cond_index] - denoised_uncond[i]) * (weight * cond_scale) / len(conds)
+                avg_weight = 0.0
+                for _, weight in conds:
+                    avg_weight += weight / len(conds)
+                denoised[i] += (x_out[i] - denoised_uncond[i]) * (avg_weight * cond_scale)
             return denoised
-
+        
         def combine_denoised_for_edit_model(self, x_out, cond_scale):
             out_cond, out_img_cond, out_uncond = x_out.chunk(3)
             denoised = out_uncond + cond_scale * (out_cond - out_img_cond) + self.image_cfg_scale * (out_img_cond - out_uncond)


### PR DESCRIPTION
## Description

Prior fix #153 fixed a crash based on improper indexing, but failed to account for the underlying logic not combining noise properly.

This fix extends the fix to the actual logic, resulting in usable `AND` prompts and overall increase in quality of image generation.

## Screenshots/videos:
![image](https://github.com/user-attachments/assets/2986c47d-e6a5-4206-963c-cfe5c52d7941)
As seen 'fox girl AND lizard boy' better combines elements of both prompts, now, without deep-frying image quality.

## Checklist:

- [X] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [X] I have performed a self-review of my own code
- [X] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
