### PR TITLE
Fix auto ztSNR detection for main branch

### DIFF
--- a/extensions-builtin/reForge-advanced_model_sampling_backported/scripts/advanced_model_sampling_script_backported.py
+++ b/extensions-builtin/reForge-advanced_model_sampling_backported/scripts/advanced_model_sampling_script_backported.py
@@ -7,7 +7,7 @@ class AdvancedModelSamplingScript(scripts.Script):
         self.enabled = False
         self.sampling_mode = "Discrete"
         self.discrete_sampling = "v_prediction"
-        self.discrete_zsnr = True
+        self.discrete_zsnr = True  # FIXME: This produces incorrect results when disabled. Need to investigate.
         self.continuous_edm_sampling = "v_prediction"
         self.continuous_edm_sigma_max = 120.0
         self.continuous_edm_sigma_min = 0.002

--- a/extensions-builtin/reForge-advanced_model_sampling_backported/scripts/advanced_model_sampling_script_backported.py
+++ b/extensions-builtin/reForge-advanced_model_sampling_backported/scripts/advanced_model_sampling_script_backported.py
@@ -97,8 +97,6 @@ class AdvancedModelSamplingScript(scripts.Script):
         unet = p.sd_model.forge_objects.unet.clone()
 
         if self.sampling_mode == "Discrete":
-            if self.discrete_zsnr and opts.sd_noise_schedule == "Zero Terminal SNR":  # Do not apply twice, temporal fix
-                self.discrete_zsnr = False
             sampler = ModelSamplingDiscrete()
             unet = sampler.patch(unet, self.discrete_sampling, self.discrete_zsnr)[0]
         elif self.sampling_mode == "Continuous EDM":

--- a/modules/processing.py
+++ b/modules/processing.py
@@ -958,7 +958,7 @@ if opts.sd_processing == "reForge OG":
                 if p.n_iter > 1:
                     shared.state.job = f"Batch {n+1} out of {p.n_iter}"
 
-                advanced_model_sampling_script = next((x for x in p.scripts.alwayson_scripts if x.name == 'advanced model sampling for reforge'), None)
+                advanced_model_sampling_script = next((x for x in p.scripts.alwayson_scripts if x.name == 'advanced model sampling for reforge (backported)'), None)
                 force_apply_ztsnr = (
                     advanced_model_sampling_script is not None
                     and p.script_args[advanced_model_sampling_script.args_from:advanced_model_sampling_script.args_to][0]
@@ -2812,7 +2812,7 @@ elif opts.sd_processing == "reForge A1111":
                 if p.n_iter > 1:
                     shared.state.job = f"Batch {n+1} out of {p.n_iter}"
 
-                advanced_model_sampling_script = next((x for x in p.scripts.alwayson_scripts if x.name == 'advanced model sampling for reforge'), None)
+                advanced_model_sampling_script = next((x for x in p.scripts.alwayson_scripts if x.name == 'advanced model sampling for reforge (backported)'), None)
                 force_apply_ztsnr = (
                     advanced_model_sampling_script is not None
                     and p.script_args[advanced_model_sampling_script.args_from:advanced_model_sampling_script.args_to][0]

--- a/modules_forge/forge_loader.py
+++ b/modules_forge/forge_loader.py
@@ -133,6 +133,9 @@ def load_checkpoint_guess_config(sd, output_vae=True, output_clip=True, output_c
 
 @torch.no_grad()
 def load_model_for_a1111(timer, checkpoint_info=None, state_dict=None):
+    ztsnr = False
+    if state_dict:
+        ztsnr = 'ztsnr' in state_dict
     a1111_config_filename = find_checkpoint_config(state_dict, checkpoint_info)
     a1111_config = OmegaConf.load(a1111_config_filename)
     timer.record("forge solving config")
@@ -224,6 +227,7 @@ def load_model_for_a1111(timer, checkpoint_info=None, state_dict=None):
         sd_model.forge_objects.unet.model.model_sampling = model_sampling(sd_model.forge_objects.unet.model.model_config, ModelType.V_PREDICTION)
 
     sd_model.is_sd3 = False
+    sd_model.ztsnr = ztsnr
     sd_model.latent_channels = 4
     sd_model.is_sdxl = conditioner is not None
     sd_model.is_sdxl_inpaint = sd_model.is_sdxl and forge_objects.unet.model.diffusion_model.in_channels == 9


### PR DESCRIPTION
When advanced model sampling extension is set to only v-pred and ztSNR is disabled, results are incorrect. Still need to look into this.