### PR TITLE
Fix forge samplers always using Normal scheduler in img2img

### DIFF
--- a/modules_forge/forge_alter_samplers.py
+++ b/modules_forge/forge_alter_samplers.py
@@ -127,6 +127,10 @@ class AlterSampler(sd_samplers_kdiffusion.KDiffusionSampler):
         self.scheduler_name = p.scheduler
         return super().sample(p, x, conditioning, unconditional_conditioning, steps, image_conditioning)
 
+    def sample_img2img(self, p, x, noise, conditioning, unconditional_conditioning, steps=None, image_conditioning=None):
+        self.scheduler_name = p.scheduler
+        return super().sample_img2img(p, x, noise, conditioning, unconditional_conditioning, steps, image_conditioning)
+
     def get_sigmas(self, p, steps):
         if self.scheduler_name is None:
             self.scheduler_name = 'Normal'  # Default to 'Normal' if not set


### PR DESCRIPTION
Currently forge samplers always use the Normal scheduler in Img2img as the scheduler name is set in the sample function, but not  in sample_img2img. This adds a sample_img2img override to forge_alter_samplers.AlterSampler as a fix.