### PR TITLE
In CFGDenoiser forward, update model_options from patched model with model_options from arguments

### DIFF
--- a/modules/sd_samplers_cfg_denoiser.py
+++ b/modules/sd_samplers_cfg_denoiser.py
@@ -191,7 +191,10 @@ if opts.sd_sampler_cfg_denoiser == "reForge":
             model = self.inner_model.inner_model.forge_objects.unet.model
             control = self.inner_model.inner_model.forge_objects.unet.controlnet_linked_list
             extra_concat_condition = self.inner_model.inner_model.forge_objects.unet.extra_concat_condition
-            model_options = kwargs.get('model_options', self.inner_model.inner_model.forge_objects.unet.model_options)
+            model_options = self.inner_model.inner_model.forge_objects.unet.model_options
+            if kwargs.get('model_options', None):
+                model_options = model_options.copy()
+                model_options.update(kwargs['model_options'])
             seed = self.p.seeds[0]
 
             uncond_patched = forge_sampler.cond_from_a1111_to_patched_ldm(denoiser_params.text_uncond)
@@ -436,7 +439,10 @@ elif opts.sd_sampler_cfg_denoiser == "reForgeDev":
             model = self.inner_model.inner_model.forge_objects.unet.model
             control = self.inner_model.inner_model.forge_objects.unet.controlnet_linked_list
             extra_concat_condition = self.inner_model.inner_model.forge_objects.unet.extra_concat_condition
-            model_options = kwargs.get('model_options', self.inner_model.inner_model.forge_objects.unet.model_options)
+            model_options = self.inner_model.inner_model.forge_objects.unet.model_options
+            if kwargs.get('model_options', None):
+                model_options = model_options.copy()
+                model_options.update(kwargs['model_options'])
             seed = self.p.seeds[0]
 
             uncond_patched = forge_sampler.cond_from_a1111_to_patched_ldm(denoiser_params.text_uncond)


### PR DESCRIPTION
If model_options is provided in arguments to CFGDenoiser.forward (such as with the CFG++ samplers), it replaces the model_options from the patched model (inner_model.forge_objects.unet.model_options), breaking any extensions that rely on them, such as kohya_hrfix. 

Changed the behavior to copy and update the model_options from the model with those from arguments, if specified. This fixes kohya_hrfix not working with CFG++ samplers (Issue #176). 