### PR TITLE
Fully reimplement ModelPatcher.clone in UnetPatcher.clone fixes exception ('NoneType' object has no attribute 'model_size') 

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -976,7 +976,7 @@ if opts.sd_processing == "reForge OG":
                     p.sd_model.alphas_cumprod_original = p.sd_model.alphas_cumprod
                     if not getattr(opts, 'use_old_clip_g_load_and_ztsnr_application', False):
                         sd_models.apply_alpha_schedule_override(p.sd_model, p, force_apply=force_apply_ztsnr)
-                    p.sd_model.forge_objects.unet.model.model_sampling.set_sigmas(rescale_zero_terminal_snr_sigmas(p.sd_model.forge_objects.unet.model.model_sampling.sigmas))
+                    p.sd_model.forge_objects.unet.model.model_sampling.set_sigmas(rescale_zero_terminal_snr_sigmas(p.sd_model.forge_objects.unet.model.model_sampling.sigmas).to(p.sd_model.forge_objects.unet.model.device))
 
                 samples_ddim = p.sample(conditioning=p.c, unconditional_conditioning=p.uc, seeds=p.seeds, subseeds=p.subseeds, subseed_strength=p.subseed_strength, prompts=p.prompts)
 
@@ -2833,7 +2833,7 @@ elif opts.sd_processing == "reForge A1111":
                     p.sd_model.alphas_cumprod_original = p.sd_model.alphas_cumprod
                     if not getattr(opts, 'use_old_clip_g_load_and_ztsnr_application', False):
                         sd_models.apply_alpha_schedule_override(p.sd_model, p, force_apply=force_apply_ztsnr)
-                    p.sd_model.forge_objects.unet.model.model_sampling.set_sigmas(rescale_zero_terminal_snr_sigmas(p.sd_model.forge_objects.unet.model.model_sampling.sigmas))
+                    p.sd_model.forge_objects.unet.model.model_sampling.set_sigmas(rescale_zero_terminal_snr_sigmas(p.sd_model.forge_objects.unet.model.model_sampling.sigmas).to(p.sd_model.forge_objects.unet.model.device))
 
                 with devices.without_autocast() if devices.unet_needs_upcast else devices.autocast():
                     samples_ddim = p.sample(conditioning=p.c, unconditional_conditioning=p.uc, seeds=p.seeds, subseeds=p.subseeds, subseed_strength=p.subseed_strength, prompts=p.prompts)

--- a/modules_forge/unet_patcher.py
+++ b/modules_forge/unet_patcher.py
@@ -25,6 +25,9 @@ class UnetPatcher(ModelPatcher):
         n.extra_preserved_memory_during_sampling = self.extra_preserved_memory_during_sampling
         n.extra_model_patchers_during_sampling = self.extra_model_patchers_during_sampling.copy()
         n.extra_concat_condition = self.extra_concat_condition
+        n.patches_uuid = self.patches_uuid
+        n.backup = self.backup
+        n.object_patches_backup = self.object_patches_backup
         return n
 
     def add_extra_preserved_memory_during_sampling(self, memory_in_bytes: int):

--- a/modules_forge/unet_patcher.py
+++ b/modules_forge/unet_patcher.py
@@ -28,6 +28,7 @@ class UnetPatcher(ModelPatcher):
         n.patches_uuid = self.patches_uuid
         n.backup = self.backup
         n.object_patches_backup = self.object_patches_backup
+        n.parent = self
         return n
 
     def add_extra_preserved_memory_during_sampling(self, memory_in_bytes: int):


### PR DESCRIPTION
Fully reimplement ModelPatcher.clone in UnetPatcher.clone. This fixes an exception ('NoneType' object has no attribute 'model_size') when generating with loras more than once, and reduces load times when generating with loras by allowing models with patched weights to be reused.

Also fixes a minor issue with ztsnr application that resulted in minor changes when models were re-used without being offloading/reloading weights by ensuring sigmas are sent to the model device.

(Was just about to submit this for more minor issues when the major model management changes dropped)