### PR TITLE
janky block weight support for IP-Adapter

### DIFF
--- a/extensions-builtin/sd_forge_controlnet/lib_controlnet/external_code.py
+++ b/extensions-builtin/sd_forge_controlnet/lib_controlnet/external_code.py
@@ -25,8 +25,8 @@ class ControlMode(Enum):
     """
 
     BALANCED = "Balanced"
-    PROMPT = "My prompt is more important"
-    CONTROL = "ControlNet is more important"
+    PROMPT = "Prefer Prompt"
+    CONTROL = "Prefer ControlNet"
 
 
 class BatchOption(Enum):
@@ -58,6 +58,15 @@ resize_mode_aliases = {
     'Outer Fit (Shrink to Fit)': 'Resize and Fill',
     'Scale to Fit (Inner Fit)': 'Crop and Resize',
     'Envelope (Outer Fit)': 'Resize and Fill',
+}
+
+ipa_block_weight_presets = {
+    "Default"               : "1, 1, 1, 1, 1.0, 1, 1, 1, 1, 1, 1",
+    "Style"                 : "0, 0, 1, 0, 0.0, 0, 1, 0, 0, 0, 0",
+    "Style (Strong)"        : "1, 1, 1, 0, 0.0, 0, 1, 1, 1, 1, 1",
+    "Composition"           : "0, 0, 0, 0, 0.0, 1, 0, 0, 0, 0, 0", 
+    "Composition (Strong)"  : "0, 0, 0, 1, 0.0, 1, 0, 0, 0, 0, 0", 
+    "Style+Composition"     : "0, 0, 1, 1, 0.0, 1, 1, 0, 0, 0, 0", 
 }
 
 
@@ -257,6 +266,16 @@ class ControlNetUnit:
     # Note2: The field `weight` is still used in some places, e.g. reference_only,
     # even advanced_weighting is set.
     advanced_weighting: Optional[List[float]] = None
+    ipa_block_weight: Optional[str] = None
+
+    # The weight mode for PuLID.
+    # https://github.com/ToTheBeginning/PuLID
+    pulid_mode: PuLIDMode = PuLIDMode.FIDELITY
+
+    # ControlNet control type for ControlNet union model.
+    # https://github.com/xinsir6/ControlNetPlus/tree/main
+    # The value of this field is only used when the model is ControlNetUnion.
+    union_control_type: ControlNetUnionControlType = ControlNetUnionControlType.UNKNOWN
 
     # The weight mode for PuLID.
     # https://github.com/ToTheBeginning/PuLID

--- a/extensions-builtin/sd_forge_controlnet/scripts/controlnet.py
+++ b/extensions-builtin/sd_forge_controlnet/scripts/controlnet.py
@@ -492,6 +492,7 @@ class ControlNetForForgeOfficial(scripts.Script):
         params.model.negative_advanced_weighting = None
         params.model.advanced_frame_weighting = None
         params.model.advanced_sigma_weighting = None
+        params.model.target_blocks = unit.ipa_block_weight
 
         soft_weighting = {
             'input': [0.09941396206337118, 0.12050177219802567, 0.14606275417942507, 0.17704576264172736,

--- a/extensions-builtin/sd_forge_ipadapter/lib_ipadapter/IPAdapterPlus.py
+++ b/extensions-builtin/sd_forge_ipadapter/lib_ipadapter/IPAdapterPlus.py
@@ -651,6 +651,7 @@ class IPAdapterApply:
                 "start_at": ("FLOAT", { "default": 0.0, "min": 0.0, "max": 1.0, "step": 0.001 }),
                 "end_at": ("FLOAT", { "default": 1.0, "min": 0.0, "max": 1.0, "step": 0.001 }),
                 "unfold_batch": ("BOOLEAN", { "default": False }),
+                "target_blocks": ("STRING", { "default": None }),
             },
             "optional": {
                 "attn_mask": ("MASK",),
@@ -663,7 +664,25 @@ class IPAdapterApply:
 
     def apply_ipadapter(self, ipadapter, model_filename, model, weight, clip_vision=None, image=None, weight_type="original",
                         noise=None, embeds=None, attn_mask=None, start_at=0.0, end_at=1.0, unfold_batch=False,
-                        insightface=None, faceid_v2=False, weight_v2=False, instant_id=False):
+                        insightface=None, faceid_v2=False, weight_v2=False, instant_id=False,
+                        target_blocks=None):
+                    
+        logger.debug(f"IPAdapter apply_ipadapter with target_blocks: {target_blocks}")
+        
+        if target_blocks is None or target_blocks == "":
+            target_blocks = [1,1,1,1,  1,  1,1,1,1,1,1]
+        else:
+            try:
+                target_blocks = alpha_params = [float(item.strip()) for item in target_blocks.split(',')]
+            except:
+                target_blocks = []
+        
+        if len(target_blocks) < 11:
+            logger.info(f"IPAdapter invalid number of weights for target_blocks: {len(target_blocks)} < 11. Using Full.")
+            target_blocks = [1,1,1,1,  1,  1,1,1,1,1,1]
+        else:   
+            logger.info(f"IPAdapter apply_ipadapter with target_blocks: {target_blocks}")
+            
         apply_ipadapter_start = time.perf_counter()
 
         self.dtype = torch.float16 if ldm_patched.modules.model_management.should_use_fp16() else torch.float32
@@ -840,7 +859,7 @@ class IPAdapterApply:
             "sigma_end": sigma_end,
             "unfold_batch": unfold_batch,
         }
-
+        
         if not self.is_sdxl:
             for id in [1,2,4,5,7,8]: # id of input_blocks that have cross attention
                 set_model_patch_replace(work_model, patch_kwargs, ("input", id))
@@ -850,20 +869,36 @@ class IPAdapterApply:
                 patch_kwargs["number"] += 1
             set_model_patch_replace(work_model, patch_kwargs, ("middle", 0))
         else:
+            if any(x < 0 for x in target_blocks):
+                logger.debug(f"IPAdapter setting weight_type to linear due to negative weight(s)")
+                patch_kwargs["weight_type"] = "linear"
+            bw_index = 0
             for id in [4,5,7,8]: # id of input_blocks that have cross attention
                 block_indices = range(2) if id in [4, 5] else range(10) # transformer_depth
                 for index in block_indices:
+                    patch_kwargs["weight"] = self.weight * target_blocks[bw_index]
+                    logger.debug(f"IPAdapter Patch IN{id:02}-{index:02} @ {self.weight * target_blocks[bw_index]}")
                     set_model_patch_replace(work_model, patch_kwargs, ("input", id, index))
                     patch_kwargs["number"] += 1
+                bw_index += 1
+            
+            bw_index = 5
             for id in range(6): # id of output_blocks that have cross attention
                 block_indices = range(2) if id in [3, 4, 5] else range(10) # transformer_depth
                 for index in block_indices:
+                    patch_kwargs["weight"] = self.weight * target_blocks[bw_index]
+                    logger.debug(f"IPAdapter Patch OUT{id:02}-{index:02} @ {self.weight * target_blocks[bw_index]}")
                     set_model_patch_replace(work_model, patch_kwargs, ("output", id, index))
                     patch_kwargs["number"] += 1
+                bw_index += 1
+                
+            bw_index = 4    
             for index in range(10):
+                patch_kwargs["weight"] = self.weight * target_blocks[bw_index]
+                logger.debug(f"IPAdapter Patch MID0-{index:02} @ {self.weight * target_blocks[bw_index]}")
                 set_model_patch_replace(work_model, patch_kwargs, ("middle", 0, index))
                 patch_kwargs["number"] += 1
-
+            
         apply_ipadapter_time = time.perf_counter() - apply_ipadapter_start
         logger.debug(f"IPAdapter apply_ipadapter time: {apply_ipadapter_time:.2f}s")
 

--- a/extensions-builtin/sd_forge_ipadapter/scripts/forge_ipadapter.py
+++ b/extensions-builtin/sd_forge_ipadapter/scripts/forge_ipadapter.py
@@ -139,6 +139,7 @@ class IPAdapterPatcher(ControlModelPatcher):
         self.model_filename = model_filename
         self.faceid_v2 = False
         self.weight_v2 = False
+        self.target_blocks= None,
         return
 
     def process_before_every_sampling(self, process, cond, mask, *args, **kwargs):
@@ -160,6 +161,7 @@ class IPAdapterPatcher(ControlModelPatcher):
             faceid_v2=self.faceid_v2,
             weight_v2=self.weight_v2,
             attn_mask=mask.squeeze(1) if mask is not None else None,
+            target_blocks=self.target_blocks,
             **cond,
         )[0]
 


### PR DESCRIPTION
## Description

* Enables "advanced weighting" for IP-Adapter, similar to how the original A1111 ControlNet extension does it (https://github.com/Mikubill/sd-webui-controlnet/discussions/2770)
* SDXL only for now (4 IN , 1 MID, 6 OUT)
* Weights are multiplied by ControlNet strength and can be negative
* Includes a few basic presets

## Screenshots/videos:
![Screenshot 2025-01-13 012306](https://github.com/user-attachments/assets/9bce322b-c935-4353-9ea0-288ec808fa5d)

![aaa](https://github.com/user-attachments/assets/debcb1e6-0f36-4e2c-8838-c3e7b9ac710f)
