### PR TITLE
saving custom IPA weights to file

### DIFF
--- a/extensions-builtin/sd_forge_controlnet/lib_controlnet/controlnet_ui/controlnet_ui_group.py
+++ b/extensions-builtin/sd_forge_controlnet/lib_controlnet/controlnet_ui/controlnet_ui_group.py
@@ -1,3 +1,4 @@
+import os        
 import json
 import gradio as gr
 import functools
@@ -227,6 +228,7 @@ class ControlNetUiGroup(object):
         self.hr_option = None
         self.ipa_block_weight = None
         self.ipa_block_weight_selector = None
+        self.ipa_block_weight_save_button = None                                                  
         self.batch_image_dir_state = None
         self.output_dir_state = None
         self.advanced_weighting = gr.State(None)
@@ -568,19 +570,45 @@ class ControlNetUiGroup(object):
                 value="",
                 placeholder="Preset or custom 11XL weights, e.g.: 0,0,0,0, 0.5, 1,1,1,1,1,1",
             )
+            self.ipa_block_weight_save_button = ToolButton(
+                value="\U0001f4be",
+                elem_classes=["cnet-ipa-preset-save"],
+                tooltip="Save Custom Preset",
+                visible=False,
+            )                                               
             
-        # Function to control visibility of the text box
+        IPA_CW_PATH = os.path.join("tmp", "ipa_custom_block_weight.txt")
         def toggle_ipa_controlls(choice):
             if choice == "IP-Adapter":
                 return gr.update(visible=True)
             else:
                 return gr.update(visible=False)
+                
+        def handle_dropdown_selection(alias):
+            if "Custom" not in alias:
+                return external_code.ipa_block_weight_presets.get(alias, "")
+            else:
+                if os.path.exists(IPA_CW_PATH):
+                    with open(IPA_CW_PATH, "r") as file:
+                        return file.readline().strip()
+                else:
+                    return ""
+                    
+        def fn_save_ipa_custom(value):
+            with open(IPA_CW_PATH, "w") as file:
+                file.write(value)
+            return gr.Dropdown.update(value=list(external_code.ipa_block_weight_presets.keys())[-1])
+                
         self.type_filter.change(toggle_ipa_controlls, inputs=self.type_filter, outputs=self.ipa_block_weight)
         self.type_filter.change(toggle_ipa_controlls, inputs=self.type_filter, outputs=self.ipa_block_weight_selector)
-        
-        def handle_dropdown_selection(alias):
-            return external_code.ipa_block_weight_presets.get(alias, "")
+        self.type_filter.change(toggle_ipa_controlls, inputs=self.type_filter, outputs=self.ipa_block_weight_save_button)                                                                                                                    
         self.ipa_block_weight_selector.change(handle_dropdown_selection,inputs=self.ipa_block_weight_selector,outputs=self.ipa_block_weight)
+        self.ipa_block_weight_save_button.click(
+            fn=fn_save_ipa_custom,
+            inputs=self.ipa_block_weight,
+            outputs=self.ipa_block_weight_selector,
+            show_progress=False,
+        )
             
         self.resize_mode = gr.Radio(
             choices=[e.value for e in external_code.ResizeMode],

--- a/extensions-builtin/sd_forge_controlnet/lib_controlnet/external_code.py
+++ b/extensions-builtin/sd_forge_controlnet/lib_controlnet/external_code.py
@@ -65,6 +65,7 @@ ipa_block_weight_presets = {
     "Composition"           : "0, 0, 0, 0, 0.0, 1, 0, 0, 0, 0, 0", 
     "Composition (Strong)"  : "0, 0, 0, 1, 0.0, 1, 0, 0, 0, 0, 0", 
     "Style+Composition"     : "0, 0, 1, 1, 0.0, 1, 1, 0, 0, 0, 0", 
+    "Custom"                : "",
 }
 
 


### PR DESCRIPTION
Adds a single "Custom" preset to the advanced weight dropdown, allowing the user to store and load **one** custom set of weights to/from file (simply written to _./tmp/ipa_custom_block_weight.txt_; I don't know how to json).
Because I got tired copy-pasting from a text file.

![Screenshot 2025-01-24 022001](https://github.com/user-attachments/assets/b7d9fae1-8ce5-4ff8-ab59-12a79f9f85a8)

Shouldn't break anything.