### PR TITLE
add .avif mimetype

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -41,6 +41,7 @@ mimetypes.add_type('application/javascript', '.js')
 
 # Likewise, add explicit content-type header for certain missing image types
 mimetypes.add_type('image/webp', '.webp')
+mimetypes.add_type('image/avif', '.avif')
 
 # override potentially incorrect mimetypes
 mimetypes.add_type('text/css', '.css')


### PR DESCRIPTION
## Description

Simply adds a line of code to add .avif mimetype.
I noticed that some browsers recognizes .avif images from reForge as txt file.
Adding mimetype of .avif fixes this behaviour.
Please consider merging if you like it. Thanks!

## Screenshots/videos:
![{F5FB71EE-FFE4-4AC1-B735-D02FB9731A4B}](https://github.com/user-attachments/assets/94bc37a7-1873-4a91-bb1c-81dabe8626f4)
![aaa](https://github.com/user-attachments/assets/3bd67944-a26a-449f-99bd-809c80411643)


## Checklist:

- [v] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [v] I have performed a self-review of my own code
- [v] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [v] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
