### PR TITLE
fix UnboundLocalError reference before assignment in extras upscaler

### DIFF
--- a/modules/stealth_infotext.py
+++ b/modules/stealth_infotext.py
@@ -156,7 +156,6 @@ def read_info_from_image_stealth(image):
                 decoded_data = gzip.decompress(bytes(byte_data)).decode('utf-8')
             else:
                 decoded_data = byte_data.decode('utf-8', errors='ignore')
-            geninfo = decoded_data
+            return decoded_data
         except:
             pass
-    return geninfo


### PR DESCRIPTION
## Description

Using upscaler in Extras tab give error `UnboundLocalError: local variable 'geninfo' referenced before assignment`. Return statement improperly scoped in script, so I fixed it.

## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
