### PR TITLE
Zoom and Panning on ForgeCanvas for mobile & Other Bugfixes

### DIFF
--- a/modules/gradio_extensions.py
+++ b/modules/gradio_extensions.py
@@ -177,3 +177,21 @@ class Dependency(gr.events.Dependency):
 gr.events.Dependency = Dependency
 
 gr.Box = gr.Group
+
+def patched_url_ok(url: str) -> bool:
+    # Retry for longer i guess.
+    import httpx, time
+    try:
+        for _ in range(5*60):
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore")
+                r = httpx.head(url, timeout=3, verify=False)
+            if r.status_code in (200, 401, 302):  # 401 or 302 if auth is set
+                return True
+            time.sleep(0.500)
+    except (ConnectionError, httpx.ConnectError):
+        return False
+    return False
+
+
+gradio.networking.url_ok = patched_url_ok

--- a/modules/infotext_utils.py
+++ b/modules/infotext_utils.py
@@ -74,29 +74,38 @@ def image_from_url_text(filedata):
     if filedata is None:
         return None
 
-    if type(filedata) == list and filedata and type(filedata[0]) == dict and filedata[0].get("is_file", False):
+    if isinstance(filedata, list):
+        if len(filedata) == 0:
+            return None
+
         filedata = filedata[0]
 
+    if isinstance(filedata, dict) and filedata.get("is_file", False):
+        filedata = filedata
+
+    filename = None
     if type(filedata) == dict and filedata.get("is_file", False):
         filename = filedata["name"]
+
+    elif isinstance(filedata, tuple) and len(filedata) == 2:  # gradio 4.16 sends images from gallery as a list of tuples
+        return filedata[0]
+
+    if filename:
         is_in_right_dir = ui_tempdir.check_tmp_file(shared.demo, filename)
         assert is_in_right_dir, 'trying to open image file outside of allowed directories'
 
         filename = filename.rsplit('?', 1)[0]
         return images.read(filename)
 
-    if type(filedata) == list:
-        if len(filedata) == 0:
-            return None
+    if isinstance(filedata, str):
+        if filedata.startswith("data:image/png;base64,"):
+            filedata = filedata[len("data:image/png;base64,"):]
 
-        filedata = filedata[0]
+        filedata = base64.decodebytes(filedata.encode('utf-8'))
+        image = images.read(io.BytesIO(filedata))
+        return image
 
-    if filedata.startswith("data:image/png;base64,"):
-        filedata = filedata[len("data:image/png;base64,"):]
-
-    filedata = base64.decodebytes(filedata.encode('utf-8'))
-    image = images.read(io.BytesIO(filedata))
-    return image
+    return None
 
 
 def add_paste_fields(tabname, init_img, fields, override_settings_component=None):

--- a/modules/initialize.py
+++ b/modules/initialize.py
@@ -5,9 +5,6 @@ import sys
 import warnings
 import os
 
-from threading import Thread
-
-from modules import gradio_extensions
 from modules.timer import startup_timer
 
 
@@ -51,7 +48,12 @@ def imports():
     shared_init.initialize()
     startup_timer.record("initialize shared")
 
-    from modules import processing, ui  # noqa: F401
+    # XXX: Import of gradio_extensions here to ensure that hijacks are applied correctly.
+    # I have no idea why, I don't want to know why but...
+    # This apparently fixes `sd-webui-infinite-image-browsing`'s
+    # AttributeError: Cannot call change outside of a gradio.Blocks context.
+    # - Ristellise
+    from modules import processing, gradio_extensions, ui  # noqa: F401
     startup_timer.record("other imports")
 
 


### PR DESCRIPTION
## Description

This is a bugfix and small feature PR to be rolled into dev2 (Gradio 4 Branch).

### Feat: Zoom and Pan on mobile devices

* Original PR from @NoCrypt. Adds support for mobile zoom and pan for image canvas
* Adds a button that toggles between draw and pan/zoom.

### Bugfix: Import of `gradio_extensions` within `modules/initialize.py`

* See code comment. It's pretty horrifying.

### Bugfix: `infotext_utils.py`'s `image_from_url_text`

* Fixes saving of images.