### PR TITLE
Fixed controlnet batch folder functionality

### DIFF
--- a/extensions-builtin/sd_forge_controlnet/scripts/controlnet.py
+++ b/extensions-builtin/sd_forge_controlnet/scripts/controlnet.py
@@ -372,7 +372,7 @@ class ControlNetForForgeOfficial(scripts.Script):
         else:
             hr_option = HiResFixOption.BOTH
 
-        alignment_indices = [i % len(preprocessor_outputs) for i in range(p.batch_size)]
+        alignment_indices = [i % len(preprocessor_outputs) for i in range(p.batch_size * p.n_iter)]
         def attach_extra_result_image(img: np.ndarray, is_high_res: bool = False):
             if (
                 (is_high_res and hr_option.high_res_enabled) or
@@ -472,11 +472,11 @@ class ControlNetForForgeOfficial(scripts.Script):
             return
 
         if is_hr_pass:
-            cond = params.control_cond_for_hr_fix
-            mask = params.control_mask_for_hr_fix
+            cond = torch.split(params.control_cond_for_hr_fix, p.batch_size)[p.iteration]
+            mask = torch.split(params.control_mask_for_hr_fix, p.batch_size)[p.iteration]
         else:
-            cond = params.control_cond
-            mask = params.control_mask
+            cond = torch.split(params.control_cond, p.batch_size)[p.iteration]
+            mask = torch.split(params.control_mask, p.batch_size)[p.iteration]
 
         kwargs.update(dict(
             unit=unit,

--- a/extensions-builtin/sd_forge_controlnet/scripts/controlnet.py
+++ b/extensions-builtin/sd_forge_controlnet/scripts/controlnet.py
@@ -473,10 +473,10 @@ class ControlNetForForgeOfficial(scripts.Script):
 
         if is_hr_pass:
             cond = torch.split(params.control_cond_for_hr_fix, p.batch_size)[p.iteration]
-            mask = torch.split(params.control_mask_for_hr_fix, p.batch_size)[p.iteration]
+            mask = params.control_mask_for_hr_fix
         else:
             cond = torch.split(params.control_cond, p.batch_size)[p.iteration]
-            mask = torch.split(params.control_mask, p.batch_size)[p.iteration]
+            mask = params.control_mask
 
         kwargs.update(dict(
             unit=unit,


### PR DESCRIPTION
## Description

Fixes 2 bug reports (Forge):
https://github.com/lllyasviel/stable-diffusion-webui-forge/issues/208
https://github.com/lllyasviel/stable-diffusion-webui-forge/issues/287

When using the controlnet batch folder function, controlnet would only consider the first control image (batch size 1) or the first few (batch size greater than 1) control images inside the specified folder. This had 2 reasons:

1. The batch count was never taken into consideration when determining which control image to use for which image generation (in case of less control images than images to be generated (batch count * batch size).
2. For each iteration, only the first (few) image(s) was ever being used.

WIth this PR, both problems are resolved, spanning 3 lines of code.
HRFix, different batch sizes and batch counts are still supported.

Note that while I am a professional developer, my knowledge of Python, Torch, tensors, etc. is extremely limited.

