### PR TITLE
Added NoobAI custom inpainting support

### DIFF
--- a/extensions-builtin/forge_preprocessor_inpaint/scripts/preprocessor_inpaint.py
+++ b/extensions-builtin/forge_preprocessor_inpaint/scripts/preprocessor_inpaint.py
@@ -167,9 +167,53 @@ class PreprocessorInpaintLama(PreprocessorInpaintOnly):
         process.modified_noise = original_noise + self.latent.to(original_noise) / sigma_max.to(original_noise)
         return cond, mask
 
+class PreprocessorInpaintNoobAIXL(Preprocessor):
+    def __init__(self):
+        super().__init__()
+        self.name = 'inpaint_noobai_xl'
+        self.tags = ['Inpaint']
+        self.model_filename_filters = ['inpaint', 'noobai']
+        self.slider_resolution = PreprocessorParameter(visible=False)
+        self.fill_mask_with_one_when_resize_and_fill = True
+        self.expand_mask_when_resize_and_fill = True
+
+    def __call__(self, input_image, resolution=512, slider_1=None, slider_2=None, slider_3=None, input_mask=None, **kwargs):
+        if input_mask is None:
+            return input_image
+            
+        if not isinstance(input_image, np.ndarray):
+            input_image = np.array(input_image)
+        if not isinstance(input_mask, np.ndarray):
+            input_mask = np.array(input_mask)
+            
+        mask = input_mask.astype(np.float32) / 255.0
+        mask = (mask > 0.5).astype(np.float32)
+            
+        # Create a copy of the input image
+        result = input_image.copy()
+        
+        # Convert mask to proper shape if needed
+        if mask.ndim == 2:
+            mask = np.expand_dims(mask, axis=-1)
+        if mask.shape[-1] == 1:
+            mask = np.repeat(mask, 3, axis=-1)
+            
+        mask_indices = mask > 0.5
+        result[mask_indices] = 0.0
+        
+        return result
+        
+    def process_before_every_sampling(self, process, cond, mask, *args, **kwargs):
+        mask = mask.round()
+        mixed_cond = cond.clone()
+        mixed_cond = mixed_cond * (1.0 - mask)
+        
+        return mixed_cond, None
 
 add_supported_preprocessor(PreprocessorInpaint())
 
 add_supported_preprocessor(PreprocessorInpaintOnly())
 
 add_supported_preprocessor(PreprocessorInpaintLama())
+
+add_supported_preprocessor(PreprocessorInpaintNoobAIXL())


### PR DESCRIPTION
## Description

* Added support for the custom NoobAI inpainting model: https://civitai.com/models/1376234/noobai-inpainting-controlnet
* Added a new class in .\extensions-builtin\forge_preprocessor_inpaint\scripts\preprocessor_inpaint.py
* To use the new preprocessor, open controlnet and select `inpaint_noobai_xl` as the preprocessor
## Screenshots/videos:
![image](https://github.com/user-attachments/assets/553b0427-714e-4584-8cce-f02140488fae)



## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
