### PR TITLE
Optional saving comments to file + Multiline comments + Comfy style c…

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -22,6 +22,7 @@ from modules.rng import slerp # noqa: F401
 from modules.sd_hijack import model_hijack
 from modules.sd_samplers_common import images_tensor_to_samples, decode_first_stage, approximation_indexes
 from modules.shared import opts, cmd_opts, state
+import modules.processing_scripts.comments as comments_parser
 import modules.shared as shared
 import modules.paths as paths
 import modules.face_restoration
@@ -1030,7 +1031,16 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
                 x_samples_ddim = batch_params.images
 
             def infotext(index=0, use_main_prompt=False):
-                return create_infotext(p, p.prompts, p.seeds, p.subseeds, use_main_prompt=use_main_prompt, index=index, all_negative_prompts=p.negative_prompts)
+                if shared.opts.enable_prompt_comments:
+                    commented_prompts = p.prompts
+                    commented_prompts[index] = p.prompt
+                    commented_negative_prompts = p.negative_prompts
+                    commented_negative_prompts[index] = p.negative_prompt
+                    return create_infotext(p, commented_prompts, p.seeds, p.subseeds, use_main_prompt=False, index=index, all_negative_prompts=commented_negative_prompts)
+                else:
+                    clean_prompts = [comments_parser.strip_comments(prompt) for prompt in p.prompts]
+                    clean_negative_prompts = [comments_parser.strip_comments(negative_prompt) for negative_prompt in p.negative_prompts]
+                    return create_infotext(p, clean_prompts, p.seeds, p.subseeds, use_main_prompt=False, index=index, all_negative_prompts=clean_negative_prompts)
 
             save_samples = p.save_samples()
 
@@ -1276,11 +1286,11 @@ class StableDiffusionProcessingTxt2Img(StableDiffusionProcessing):
 
             def get_hr_prompt(p, index, prompt_text, **kwargs):
                 hr_prompt = p.all_hr_prompts[index]
-                return hr_prompt if hr_prompt != prompt_text else None
+                return hr_prompt if hr_prompt != (comments_parser.strip_comments(prompt_text) if shared.opts.enable_prompt_comments else prompt_text) else None
 
             def get_hr_negative_prompt(p, index, negative_prompt, **kwargs):
                 hr_negative_prompt = p.all_hr_negative_prompts[index]
-                return hr_negative_prompt if hr_negative_prompt != negative_prompt else None
+                return hr_negative_prompt if hr_negative_prompt != (comments_parser.strip_comments(negative_prompt) if shared.opts.enable_prompt_comments else negative_prompt) else None
 
             self.extra_generation_params["Hires prompt"] = get_hr_prompt
             self.extra_generation_params["Hires negative prompt"] = get_hr_negative_prompt

--- a/modules/processing_scripts/comments.py
+++ b/modules/processing_scripts/comments.py
@@ -3,8 +3,14 @@ import re
 
 
 def strip_comments(text):
-    text = re.sub('(^|\n)#[^\n]*(\n|$)', '\n', text)  # while line comment
-    text = re.sub('#[^\n]*(\n|$)', '\n', text)  # in the middle of the line comment
+    text = re.sub('(^\/\*.*?\*\/(\n|$))(?m)(?s)', '\n', text)  # multiline comments (/* */)
+    text = re.sub('(^#.*(\n|$))(?m)', '\n', text)  # whole line comment (#)
+    text = re.sub('(^\/\/.*(\n|$))(?m)', '\n', text)  # whole line comment (//)
+    text = re.sub('(#.*\n|$)', '\n', text)  # in the middle of the line comment (#)
+    text = re.sub('(\/\/.*\n|$)', '\n', text)  # in the middle of the line comment (//)
+    text = re.sub('(^\/\*(\n|$))|(\*\/(\n|$))', '\n', text)  # dangling multiline comment brackets (/* */)
+    #text = re.sub('[\n]{3,}', '\n\n', text)  # remove multiple consecutive newlines
+    #text = re.sub('[ ]{2,}', ' ', text)  # remove multiple consecutive spaces
 
     return text
 
@@ -17,9 +23,6 @@ class ScriptStripComments(scripts.Script):
         return scripts.AlwaysVisible
 
     def process(self, p, *args):
-        if not shared.opts.enable_prompt_comments:
-            return
-
         p.all_prompts = [strip_comments(x) for x in p.all_prompts]
         p.all_negative_prompts = [strip_comments(x) for x in p.all_negative_prompts]
 
@@ -35,9 +38,6 @@ class ScriptStripComments(scripts.Script):
 
 
 def before_token_counter(params: script_callbacks.BeforeTokenCounterParams):
-    if not shared.opts.enable_prompt_comments:
-        return
-
     params.prompt = strip_comments(params.prompt)
 
 
@@ -45,5 +45,5 @@ script_callbacks.on_before_token_counter(before_token_counter)
 
 
 shared.options_templates.update(shared.options_section(('sd', "Stable Diffusion", "sd"), {
-    "enable_prompt_comments": shared.OptionInfo(True, "Enable comments").info("Use # anywhere in the prompt to hide the text between # and the end of the line from the generation."),
+    "enable_prompt_comments": shared.OptionInfo(True, "Save comments").info("Toggles saving of comments in finished image files. Use # anywhere in the prompt to hide the text between # and the end of the line from the generation. For multiline comments, use /* to open and */ to close."),
 }))


### PR DESCRIPTION
Optional saving comments to file + Multiline comments + Comfy style comments + Comment processing changes

Save comments within the prompt in png text chunk. Controlled via Settings -> Stable Diffusion -> Stable Diffusion -> Save comments.

/* */ style multiline comment support.

// style single line comment processing (Comfy UI uses these instead of # comments, so I added this for compatibility's sake).

Added some whitespace trimming regex. This may be bit out of scope for this commit, so commenting it out. Could add a separate option to handle this.

Removed returns in comments.py because the program hangs when generating an image if saving comments is disabled with these changes active. Not sure why it does this, I'm not knowledgeable enough to get to the bottom of it. **_These changes force comments to always be processed internally, so #, //, /*, and */ sequences are no longer valid symbols that can be used in prompts_**.

Passes tests with option on and off.
Loading prompts from PNG Info tab functions normally.

Definitely open to ideas! I can see there being several additional options to control this behavior, I'm just not sure which direction to go in.