### PR TITLE
stealth info text support for webp

### DIFF
--- a/modules/stealth_infotext.py
+++ b/modules/stealth_infotext.py
@@ -8,7 +8,7 @@ def add_stealth_pnginfo(params: ImageSaveParams):
     stealth_pnginfo_opt = shared.opts.data.get('stealth_pnginfo_opt', 'Alpha')
     if not stealth_pnginfo_opt or stealth_pnginfo_opt == 'None':
         return
-    if not params.filename.endswith('.png') or params.pnginfo is None:
+    if not params.filename.endswith(('.png', '.webp')) or params.pnginfo is None:
         return
     if 'parameters' not in params.pnginfo:
         return


### PR DESCRIPTION
stealth info text works with webp now, lossy or lossless, achieved by always encoding the alpha layer losslessly.

