### PR TITLE
Fix incorrect enabling of xformers causing crash on startup

### DIFF
--- a/ldm_patched/modules/model_management.py
+++ b/ldm_patched/modules/model_management.py
@@ -238,6 +238,7 @@ except:
 
 XFORMERS_VERSION = ""
 XFORMERS_ENABLED_VAE = True
+XFORMERS_IS_AVAILABLE = True
 if args.disable_xformers:
     XFORMERS_IS_AVAILABLE = False
 else:
@@ -1088,6 +1089,8 @@ def flash_attention_enabled():
 def xformers_enabled():
     global directml_enabled
     global cpu_state
+    if sys.modules.get("xformers") is None:
+        return False
     if cpu_state != CPUState.GPU:
         return False
     if is_intel_xpu():


### PR DESCRIPTION
## Description
Checks `sys.modules` in `xformers_enabled()` check so that we don't try to load xformers if it's been disabled at launch.

## Checklist:

- [X] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [X] I have performed a self-review of my own code
- [X] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [X] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
