### PR TITLE
Fix of diffuser peft version error when start up

### DIFF
--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -37,6 +37,7 @@ gradio_rangeslider==0.0.6
 gradio_imageslider==0.0.20
 loadimg==0.1.2
 tqdm==4.66.1
-peft==0.13.2
+peft==0.15.0
 pydantic==2.8.2
+
 huggingface-hub>=0.26.2


### PR DESCRIPTION


## Description

When using the dendev branch, an peft version error generate by diffusers when startup
This commit change requirement to 0.15.0, the mimium requirement for diffuser FLUX pipline to work.

## My test result
After fix, the WebUI start normally.

## Screenshots/videos:


## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
