### PR TITLE
add epsilon scaling

### DIFF
--- a/modules/shared_options.py
+++ b/modules/shared_options.py
@@ -250,6 +250,11 @@ options_templates.update(options_section(('sd_sampling', "SD Sampling backend fo
     ),
 }))
 
+options_templates.update(options_section(('epsilon_scaling', "Epsilon Scaling", "sd"), {
+    "epsilon_scaling_enabled": OptionInfo(False, "Enable epsilon scaling").info("Scale the guided prediction to mitigate exposure bias during sampling."),
+    "epsilon_scaling_factor": OptionInfo(1.005, "Epsilon scaling factor", gr.Slider, {"minimum": 0.5, "maximum": 1.5, "step": 0.001}).info("Noise scaling multiplier from 'Elucidating the Exposure Bias in Diffusion Models'."),
+}))
+
 options_templates.update(options_section(('img2img', "img2img", "sd"), {
     "inpainting_mask_weight": OptionInfo(1.0, "Inpainting conditioning mask strength", gr.Slider, {"minimum": 0.0, "maximum": 1.0, "step": 0.01}, infotext='Conditional mask weight'),
     "initial_noise_multiplier": OptionInfo(1.0, "Noise multiplier for img2img", gr.Slider, {"minimum": 0.0, "maximum": 1.5, "step": 0.001}, infotext='Noise multiplier'),


### PR DESCRIPTION
## Description
 https://github.com/comfyanonymous/ComfyUI/pull/10132

Adds epsilon scaling based on this paper https://openreview.net/pdf?id=xEJMoj1SpX

In practice seems to reliably improve small details and backgrounds in particular.
Safe values for anime seems to be up to 1.03 or so, with 1.02 being quite nice from what i see.

## Screenshots/videos:
1.0(off)
<img width="832" height="1216" alt="изображение" src="https://github.com/user-attachments/assets/1077e4f5-3b2b-4aa2-b77f-0611ee101215" />
1.02
<img width="832" height="1216" alt="изображение" src="https://github.com/user-attachments/assets/838307b4-3ebe-4a0a-8495-05498196fa6a" />
