### PR TITLE
Fix: Preserve full Negative Prompt (including Styles) in PNG Info when prompt comments are enabled

### DIFF
--- a/modules/processing.py
+++ b/modules/processing.py
@@ -1032,10 +1032,10 @@ def process_images_inner(p: StableDiffusionProcessing) -> Processed:
 
             def infotext(index=0, use_main_prompt=False):
                 if shared.opts.enable_prompt_comments_def:
-                    commented_prompts = p.prompts
-                    commented_prompts[index] = p.prompt
-                    commented_negative_prompts = p.negative_prompts
-                    commented_negative_prompts[index] = p.negative_prompt
+                    commented_prompts = list(p.prompts)
+                    commented_prompts[index] = p.all_prompts[index]
+                    commented_negative_prompts = list(p.negative_prompts)
+                    commented_negative_prompts[index] = p.all_negative_prompts[index]
                     return create_infotext(p, commented_prompts, p.seeds, p.subseeds, use_main_prompt=False, index=index, all_negative_prompts=commented_negative_prompts)
                 else:
                     clean_prompts = [comments_parser.strip_comments(prompt) for prompt in p.prompts]
@@ -1845,3 +1845,4 @@ class StableDiffusionProcessingImg2Img(StableDiffusionProcessing):
 
     def get_token_merging_ratio(self, for_hr=False):
         return self.token_merging_ratio or ("token_merging_ratio" in self.override_settings and opts.token_merging_ratio) or opts.token_merging_ratio_img2img or opts.token_merging_ratio
+


### PR DESCRIPTION
#### Summary
This PR fixes an issue where the **Negative Prompt Styles** (e.g., `(white hair:1.6)`) are stripped from the PNG Info (`infotext`) when the `enable_prompt_comments_def` option is enabled in the settings. The bug was caused by the `infotext` function unintentionally overwriting the fully applied negative prompt with the original, short user input prompt.

---

## Description

* **a simple description of what you're trying to accomplish**
    Fixes a bug where Negative Prompt styles are lost in PNG Info when the prompt comments feature is active. This ensures the generated image metadata is accurate for regeneration.

* **a summary of changes in code**
    In `modules/processing.py`'s `infotext` function, the prompt variables used for overwriting (`p.prompt` and `p.negative_prompt`) have been replaced with the fully style-applied versions (`p.all_prompts[index]` and `p.all_negative_prompts[index]`). Additionally, `list()` calls were confirmed as necessary and maintained to prevent data corruption via implicit reference passing.

* **which issues it fixes, if any**
    No associated issue/ticket, this is a community reported/found bug.

---

#### Detailed Problem Description
When `shared.opts.enable_prompt_comments_def` is true, the original logic was unintentionally performing two problematic actions:
1.  **Implicit Reference Passing**: The absence of `list()` on the original prompt variables risked permanent corruption of the `p` object's internal prompt lists.
2.  **Short Prompt Overwrite**: The fully styled prompt (e.g., `nsfw,, (white hair:1.6),`) was overwritten by the short, unstyled user input (`nsfw,`), causing the loss of styles in the PNG Info output.

#### Solution & Code Changes
The fix addresses both issues:

```python
# Before (Original Code - Implicit Reference Passing & Short Prompt Overwrite)
# commented_prompts = p.prompts
# commented_prompts[index] = p.prompt
# commented_negative_prompts = p.negative_prompts
# commented_negative_prompts[index] = p.negative_prompt

# After (Final, Corrected Code)
commented_prompts = list(p.prompts)
commented_prompts[index] = p.all_prompts[index]
commented_negative_prompts = list(p.negative_prompts)
commented_negative_prompts[index] = p.all_negative_prompts[index]

## Screenshots/videos:
N/A (This is a metadata/infotext fix, no visual change to the output image itself.)

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [x] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
