### PR TITLE
Fix UnboundLocalError in DPM++ 2M/3M SDE samplers

### DIFF
--- a/k_diff/k_diffusion/sampling.py
+++ b/k_diff/k_diffusion/sampling.py
@@ -647,8 +647,9 @@ def sample_dpmpp_2m_sde(model, x, sigmas, extra_args=None, callback=None, disabl
             if eta:
                 x = x + noise_sampler(sigmas[i], sigmas[i + 1]) * sigmas[i + 1] * (-2 * eta_h).expm1().neg().sqrt() * s_noise
 
+            h_last = h
+
         old_denoised = denoised
-        h_last = h
     return x
 
 
@@ -697,6 +698,7 @@ def sample_dpmpp_3m_sde(model, x, sigmas, extra_args=None, callback=None, disabl
             if eta:
                 x = x + noise_sampler(sigmas[i], sigmas[i + 1]) * sigmas[i + 1] * (-2 * h * eta).expm1().neg().sqrt() * s_noise
 
+            h_1, h_2 = h, h_1
+
         denoised_1, denoised_2 = denoised, denoised_1
-        h_1, h_2 = h, h_1
     return x


### PR DESCRIPTION
Move h_last and h_1/h_2 assignments inside the else block where 'h' is defined. Fixes crash when using these samplers with low step counts or high denoising strength in img2img.

## Description

* Fix unbound error that occurs when using DPM++ 2M SDE or DPM++ 3M SDE sampler, resulting in crashing execution for the given API call.

## Reproduction
  1. Use img2img API endpoint (`/sdapi/v1/img2img`)
  2. Select DPM++ 2M SDE or DPM++ 3M SDE sampler
  3. Use very low step count (1-2 steps) OR high denoising strength
  4. The error occurs because `sigmas[i+1] == 0` triggers the denoising branch where `h` is never assigned

The sampler loop iterates over a sigmas array. When steps are minimal, the array is very short (e.g., [sigma_start, 0]).

```Python
  for i in range(len(sigmas) - 1):
      if sigmas[i + 1] == 0:
          x = denoised           # 'h' is NOT defined here
      else:
          h = s - t              # 'h' is ONLY defined here
          ...

      h_last = h                 # ERROR: 'h' may not exist!
```

## Error log:

```
*** API error: POST: http://127.0.0.1:7860/sdapi/v1/img2img {'error': 'UnboundLocalError', 'detail': '', 'body': '', 'errors': "local variable 'h' referenced before assignment"}
    Traceback (most recent call last):
      File "C:\Users\max\.conda\envs\reforge\lib\site-packages\anyio\streams\memory.py", line 98, in receive
        return self.receive_nowait()
      File "C:\Users\max\.conda\envs\reforge\lib\site-packages\anyio\streams\memory.py", line 93, in receive_nowait
        raise WouldBlock
    anyio.WouldBlock

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "C:\Users\max\.conda\envs\reforge\lib\site-packages\starlette\middleware\base.py", line 78, in call_next
        message = await recv_stream.receive()
      File "C:\Users\max\.conda\envs\reforge\lib\site-packages\anyio\streams\memory.py", line 118, in receive
        raise EndOfStream
    anyio.EndOfStream

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "D:\stable-diffusion\reForge\modules\api\api.py", line 186, in exception_handling
        return await call_next(request)
      File "C:\Users\max\.conda\envs\reforge\lib\site-packages\starlette\middleware\base.py", line 84, in call_next
        raise app_exc
      File "C:\Users\max\.conda\envs\reforge\lib\site-packages\starlette\middleware\base.py", line 70, in coro
        await self.app(scope, receive_or_disconnect, send_no_error)
      File "C:\Users\max\.conda\envs\reforge\lib\site-packages\starlette\middleware\base.py", line 108, in __call__
        response = await self.dispatch_func(request, call_next)
      File "D:\stable-diffusion\reForge\modules\api\api.py", line 150, in log_and_time
        res: Response = await call_next(req)
      File "C:\Users\max\.conda\envs\reforge\lib\site-packages\starlette\middleware\base.py", line 84, in call_next
        raise app_exc
      File "C:\Users\max\.conda\envs\reforge\lib\site-packages\starlette\middleware\base.py", line 70, in coro
        await self.app(scope, receive_or_disconnect, send_no_error)
      File "C:\Users\max\.conda\envs\reforge\lib\site-packages\starlette\middleware\cors.py", line 84, in __call__
        await self.app(scope, receive, send)
      File "C:\Users\max\.conda\envs\reforge\lib\site-packages\starlette\middleware\gzip.py", line 26, in __call__
        await self.app(scope, receive, send)
      File "C:\Users\max\.conda\envs\reforge\lib\site-packages\starlette\middleware\exceptions.py", line 79, in __call__
        raise exc
      File "C:\Users\max\.conda\envs\reforge\lib\site-packages\starlette\middleware\exceptions.py", line 68, in __call__
        await self.app(scope, receive, sender)
      File "C:\Users\max\.conda\envs\reforge\lib\site-packages\fastapi\middleware\asyncexitstack.py", line 21, in __call__
        raise e
      File "C:\Users\max\.conda\envs\reforge\lib\site-packages\fastapi\middleware\asyncexitstack.py", line 18, in __call__
        await self.app(scope, receive, send)
      File "C:\Users\max\.conda\envs\reforge\lib\site-packages\starlette\routing.py", line 718, in __call__
        await route.handle(scope, receive, send)
      File "C:\Users\max\.conda\envs\reforge\lib\site-packages\starlette\routing.py", line 276, in handle
        await self.app(scope, receive, send)
      File "C:\Users\max\.conda\envs\reforge\lib\site-packages\starlette\routing.py", line 66, in app
        response = await func(request)
      File "C:\Users\max\.conda\envs\reforge\lib\site-packages\fastapi\routing.py", line 237, in app
        raw_response = await run_endpoint_function(
      File "C:\Users\max\.conda\envs\reforge\lib\site-packages\fastapi\routing.py", line 165, in run_endpoint_function
        return await run_in_threadpool(dependant.call, **values)
      File "C:\Users\max\.conda\envs\reforge\lib\site-packages\starlette\concurrency.py", line 41, in run_in_threadpool
        return await anyio.to_thread.run_sync(func, *args)
      File "C:\Users\max\.conda\envs\reforge\lib\site-packages\anyio\to_thread.py", line 33, in run_sync
        return await get_asynclib().run_sync_in_worker_thread(
      File "C:\Users\max\.conda\envs\reforge\lib\site-packages\anyio\_backends\_asyncio.py", line 877, in run_sync_in_worker_thread
        return await future
      File "C:\Users\max\.conda\envs\reforge\lib\site-packages\anyio\_backends\_asyncio.py", line 807, in run
        result = context.run(func, *args)
      File "D:\stable-diffusion\reForge\modules\api\api.py", line 553, in img2imgapi
        processed = process_images(p)
      File "D:\stable-diffusion\reForge\modules\processing.py", line 826, in process_images
        res = process_images_inner(p)
      File "D:\stable-diffusion\reForge\modules\processing.py", line 987, in process_images_inner
        samples_ddim = p.sample(conditioning=p.c, unconditional_conditioning=p.uc, seeds=p.seeds, subseeds=p.subseeds, subseed_strength=p.subseed_strength, prompts=p.prompts)
      File "D:\stable-diffusion\reForge\modules\processing.py", line 1829, in sample
        samples = self.sampler.sample_img2img(self, self.init_latent, x, conditioning, unconditional_conditioning, image_conditioning=self.image_conditioning)
      File "D:\stable-diffusion\reForge\modules\sd_samplers_kdiffusion.py", line 250, in sample_img2img
        samples = self.launch_sampling(t_enc + 1, lambda: self.func(self.model_wrap_cfg, xi, extra_args=self.sampler_extra_args, disable=False, callback=self.callback_state, **extra_params_kwargs))
      File "D:\stable-diffusion\reForge\modules\sd_samplers_common.py", line 282, in launch_sampling
        return func()
      File "D:\stable-diffusion\reForge\modules\sd_samplers_kdiffusion.py", line 250, in <lambda>
        samples = self.launch_sampling(t_enc + 1, lambda: self.func(self.model_wrap_cfg, xi, extra_args=self.sampler_extra_args, disable=False, callback=self.callback_state, **extra_params_kwargs))
      File "C:\Users\max\.conda\envs\reforge\lib\site-packages\torch\utils\_contextlib.py", line 120, in decorate_context
        return func(*args, **kwargs)
      File "D:\stable-diffusion\reForge\k_diff\k_diffusion\sampling.py", line 651, in sample_dpmpp_2m_sde
        h_last = h
    UnboundLocalError: local variable 'h' referenced before assignment

---
```

## Checklist:
This is a very simple fix. No dependency or major logical changes. Its a fix for a bug caused by out of context variable usage.
