### PR TITLE
fix random resolution built-in extension behaviour

### DIFF
--- a/extensions-builtin/sd_webui_random_resolutions/scripts/random_res_script.py
+++ b/extensions-builtin/sd_webui_random_resolutions/scripts/random_res_script.py
@@ -289,14 +289,6 @@ class Script(scripts.Script):
             total = sum(weights)
             weights = [w / total for w in weights]
 
-        # We want to pick a random resolution in a somewhat reproducable way so that the user can adjust his prompt
-        # when using fixed seeds without the resolution changing -> so we just base it on the seed used for the image.
-        # When generating an image with a fixed seed the same resolution will be picked every time.
-        # When generating an image with a random seed the resolution will be random because the seed is random.
-        # When generating a batch of images the resolution will be picked based on the first image's seed.
-        # When generating multiple batches of images the resolution will be picked independently for each batch.
-        # p.seed will be -1 when the user wants to use a random seed so we use p.seeds (plural) which
-        # contains the generated random seeds or the picked fixed seeds for the current batch.
         rnd = random.Random(p.seeds[0])
         res_tuple = rnd.choices(res_list, weights=weights, k=1)[0]
         


### PR DESCRIPTION
## Description
Currently the random resolution built-in extension is behaving in a not-so-useful manner.
If you generate a single image with seed -1 multiple times (with batch count 1) it will always pick the same resolution.
If you generate multiple batches of images the picked resolutions will always follow the same pattern.
The reason is that the randomness is initialized with `p.seed` which will contain -1 instead of the actual random seed
making the generation with image seed -1 not random but completely predictable...

This PR changes the behaviour so that it will work the following way:
- The seed for the randomness picker will be the actual random seed of the batch and not -1
- When generating an image with a fixed seed the same resolution will be picked every time
- When generating an image with a random seed the resolution will be random because the seed is random
- When generating a batch of images the resolution will be picked based on the first image's seed
- When generating multiple batches of images the resolution will be picked independently for each batch

I hope its okay for you that I left the behaviour in the code as comments.

## Checklist:
I have tested the code.