### PR TITLE
Removal of invalid comment lines in requirements_versions.txt

### DIFF
--- a/requirements_versions.txt
+++ b/requirements_versions.txt
@@ -1,8 +1,5 @@
 setuptools==69.5.1  # temp fix for compatibility with some old packages
 GitPython==3.1.32
-# For adetailer, you need to install mediapipe>=0.10.30 and ultralytics manually first.
-# mediapipe>=0.10.30
-# ultralytics
 pillow==10.4.0
 accelerate==0.21.0
 blendmodes==2024.1.1


### PR DESCRIPTION
## Description
### Summary
This PR removes invalid comment lines from `requirements_versions.txt` that cause unexpected behavior.
I have already reported the details in the following issue.
[[Bug]: Since requirements_versions.txt contains comment lines, Installing requirements is always executed.  #473](https://github.com/Panchovix/stable-diffusion-webui-reForge/issues/473)

### Issues Fixed
This PR resolves the following reported issue:
[[Bug]: Since requirements_versions.txt contains comment lines, Installing requirements is always executed.  #473](https://github.com/Panchovix/stable-diffusion-webui-reForge/issues/473)

### Additional note
The comments in the deleted lines no longer make sense.
```
# For adetailer, you need to install mediapipe>=0.10.30 and ultralytics manually first.
# mediapipe>=0.10.30
# ultralytics
```
The reason this doesn't make sense is that [`adetailer/install.py`](https://github.com/Bing-su/adetailer/blob/main/install.py) automatically installs mediapipe and ultralytics.
For your reference, when you install reForge for the first time, mediapipe 0.10.33 will be installed as required by handrefinerportable.

## Checklist:

- [x] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [x] I have performed a self-review of my own code
- [x] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [ ] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
