### PR TITLE
Fix AlterSampler seed reproducibility

### DIFF
--- a/ldm_patched/k_diffusion/sampling.py
+++ b/ldm_patched/k_diffusion/sampling.py
@@ -239,12 +239,24 @@ def get_ancestral_step(sigma_from, sigma_to, eta=None):
 
 def default_noise_sampler(x, seed=None):
     if seed is not None:
+        # ComfyUI path (see ldm_patched/modules/samplers.py:1163): an explicit
+        # seed is supplied via extra_args. Build a fresh torch.Generator and
+        # use torch.randn with it. This branch is byte-identical to the
+        # previous implementation so the Comfy sampling path is untouched.
         generator = torch.Generator(device=x.device)
         generator.manual_seed(seed)
-    else:
-        generator = None
+        return lambda sigma, sigma_next: torch.randn(x.size(), dtype=x.dtype, layout=x.layout, device=x.device, generator=generator)
 
-    return lambda sigma, sigma_next: torch.randn(x.size(), dtype=x.dtype, layout=x.layout, device=x.device, generator=generator)
+    # WebUI path: no explicit seed. Route through torch.randn_like so that
+    # modules/sd_samplers_common.py::TorchHijack (installed on this module's
+    # `torch` attribute in Sampler.initialize) can intercept the call and
+    # return seeded noise from p.rng.next(). Regular WebUI k-diffusion
+    # samplers have used this hijack-based reproducibility mechanism on the
+    # A1111 backend for a long time via k_diff.k_diffusion.sampling, which
+    # already uses torch.randn_like. Switching this branch to torch.randn_like
+    # extends the same reproducibility path to AlterSamplers, which always
+    # route through ldm_patched.k_diffusion.sampling regardless of backend.
+    return lambda sigma, sigma_next: torch.randn_like(x)
 
 def ei_h_phi_1(h: torch.Tensor) -> torch.Tensor:
     """Compute the result of h*phi_1(h) in exponential integrator methods."""

--- a/modules/sd_samplers_common.py
+++ b/modules/sd_samplers_common.py
@@ -334,6 +334,22 @@ class Sampler:
 
         sampling.torch = TorchHijack(p)
 
+        # AlterSamplers (modules_forge/forge_alter_samplers.py) unconditionally
+        # bind to functions from ldm_patched.k_diffusion.sampling regardless of
+        # opts.sd_sampling, so when the A1111 backend is selected above the
+        # hijack lands on k_diff.k_diffusion.sampling and AlterSamplers miss
+        # it. Also install the hijack on the ldm_patched module when it is a
+        # distinct module object, so the randn_like intercept applies to the
+        # sampler functions AlterSamplers actually call. When the Comfy
+        # backend is selected `sampling` already IS that module and this is a
+        # no-op.
+        try:
+            from ldm_patched.k_diffusion import sampling as _ldm_patched_sampling
+        except ImportError:
+            _ldm_patched_sampling = None
+        if _ldm_patched_sampling is not None and _ldm_patched_sampling is not sampling:
+            _ldm_patched_sampling.torch = TorchHijack(p)
+
         extra_params_kwargs = {}
         for param_name in self.extra_params:
             if hasattr(p, param_name) and param_name in inspect.signature(self.func).parameters:


### PR DESCRIPTION
Stochastic AlterSamplers (ER SDE, SEEDS 2/3, SA-Solver, and the `*_cfg_pp` ancestral variants, etc.) are not seed reproducible on the WebUI path. Same prompt, same seed, different image every run. Regular k-diffusion ancestral samplers (Euler a, DPM++ 2S a) and brownian samplers (DPM++ SDE family) are already reproducible, so this is specific to the AlterSampler path.

### Root cause

reForge already has a working seed mechanism for WebUI-path samplers: `TorchHijack` in `modules/sd_samplers_common.py`. `Sampler.initialize()` does `sampling.torch = TorchHijack(p)`, which rewires `torch.randn_like` inside the k-diffusion sampling module to return `p.rng.next()`, seeded from `p.seeds` via `ImageRNG`. AlterSamplers miss this for two reasons that stack:

1. The hijack lands on the wrong module. `sd_samplers_common.py` imports `sampling` conditionally on `opts.sd_sampling`: `k_diff.k_diffusion.sampling` on the default "A1111" backend, `ldm_patched.k_diffusion.sampling` on "ldm patched (Comfy)". Line 335 hijacks whichever one. But `modules_forge/forge_alter_samplers.py` does `from ldm_patched.k_diffusion import sampling as k_diffusion_sampling` unconditionally and binds every AlterSampler to functions from that module. On the default A1111 backend, the hijack sits on `k_diff.k_diffusion.sampling` while AlterSamplers fire into `ldm_patched.k_diffusion.sampling`. Different module object, no intercept.

2. Even on the Comfy backend, `ldm_patched.k_diffusion.sampling.default_noise_sampler` bypasses the hijack. Compare:
   * `k_diff/k_diffusion/sampling.py`: `return lambda sigma, sigma_next: torch.randn_like(x)`. Uses `torch.randn_like`, which `TorchHijack.__getattr__` intercepts.
   * `ldm_patched/k_diffusion/sampling.py`: `return lambda sigma, sigma_next: torch.randn(x.size(), ..., generator=generator)`. Uses `torch.randn`, which the hijack does not intercept. `TorchHijack.__getattr__` only special cases `randn_like`, everything else falls through to real torch and hits the global CUDA RNG unseeded.

### Why not just put `seed` into `sampler_extra_args`

I tried that. It broke every AlterSampler. When extra_args carries a seed, `default_noise_sampler` takes its `if seed is not None` branch which builds a fresh `torch.Generator(device=x.device)` and `manual_seed(seed)` on the raw `p.seed`. That produces a noise trajectory unrelated to `p.rng`'s state, and multistep solvers (ER SDE Stage 3, SEEDS 2/3) have numerical fragilities that this specific trajectory exposes at certain CFG values. They "work" today because the random global RNG happens to avoid those pathological trajectories. The `TorchHijack` path gives a different deterministic trajectory, the same one regular A1111 backend ancestral samplers already use, so it has a much better chance of not tripping those fragilities.

### Changes

1. `ldm_patched/k_diffusion/sampling.py`, `default_noise_sampler`. Only the `seed is None` branch changes. It now returns `lambda sigma, sigma_next: torch.randn_like(x)`. The `seed is not None` branch is byte identical to before, so the ComfyUI path via `ldm_patched/modules/samplers.py:1163` is untouched.

2. `modules/sd_samplers_common.py`, `Sampler.initialize()`. After the existing `sampling.torch = TorchHijack(p)`, also install `TorchHijack(p)` on `ldm_patched.k_diffusion.sampling` if it is a different module object. On the Comfy backend it is the same object and the second install is a no-op. On the A1111 backend, both modules get hijacked, so AlterSamplers pick up the intercept.

No changes to `sampler_extra_args`. No changes to `ldm_patched/modules/samplers.py`. No per-sampler edits. No new context variables.

### Test plan

- [x] Same prompt and seed twice, pixel identical output on these AlterSamplers: Euler A Comfy, Euler Ancestral CFG++, DPM++ 2S Ancestral CFG++, ER SDE, SEEDS 2, SEEDS 3, SA-Solver
- [x] No regression on regular samplers: Euler a, DPM++ 2S a, DPM++ SDE, DPM++ 2M SDE
- [x] Multistep AlterSamplers at CFG 1, 3, 5, 7 on a few seeds: ER SDE, SEEDS 2/3, SA-Solver. Watch for pixel chaos or black outputs.
- [x] Both backends tested: `opts.sd_sampling == "A1111"` (default) and `"ldm patched (Comfy)"`.