### PR TITLE
Fix: pin torch 2.8.0 + xformers 0.0.32.post2 to resolve install failure

### DIFF
--- a/modules/launch_utils.py
+++ b/modules/launch_utils.py
@@ -369,7 +369,7 @@ def get_cuda_comp_cap():
 
 def prepare_environment():
     torch_index_url = os.environ.get('TORCH_INDEX_URL', "https://download.pytorch.org/whl/cu128")
-    torch_command = os.environ.get('TORCH_COMMAND', f"pip install torch==2.9.0 torchvision --extra-index-url {torch_index_url}")
+    torch_command = os.environ.get('TORCH_COMMAND', f"pip install torch==2.8.0 torchvision --extra-index-url {torch_index_url}")
     if args.use_ipex:
         if platform.system() == "Windows":
             # The "Nuullll/intel-extension-for-pytorch" wheels were built from IPEX source for Intel Arc GPU: https://github.com/intel/intel-extension-for-pytorch/tree/xpu-main
@@ -393,7 +393,7 @@ def prepare_environment():
     requirements_file = os.environ.get('REQS_FILE', "requirements_versions.txt")
     requirements_file_for_npu = os.environ.get('REQS_FILE_FOR_NPU', "requirements_npu.txt")
 
-    xformers_package = os.environ.get('XFORMERS_PACKAGE', '--index-url https://download.pytorch.org/whl/cu128 xformers')
+    xformers_package = os.environ.get('XFORMERS_PACKAGE', '--index-url https://download.pytorch.org/whl/cu128 xformers==0.0.32.post2')
     clip_package = os.environ.get('CLIP_PACKAGE', "https://github.com/openai/CLIP/archive/d50d76daa670286dd6cacf3bcd80b5e4823fc8e1.zip")
     openclip_package = os.environ.get('OPENCLIP_PACKAGE', "https://github.com/mlfoundations/open_clip/archive/bb6e834e9c70d9c27d0dc3ecedeebeaeb1ffad6b.zip")
 


### PR DESCRIPTION
  ---
  Description

  - Fixes broken fresh install caused by torch/xformers version mismatch on the cu128 index
  - Pins torch==2.8.0 and xformers==0.0.32.post2 in modules/launch_utils.py — a known-good compatible pair
  - launch_utils.py currently pins torch==2.9.0 but leaves xformers unpinned. There is no released xformers compatible with torch 2.9.0:
    - cu128 index has xformers 0.0.32.post2 (requires torch 2.8.0)
    - Latest stable xformers 0.0.33.post1 (requires torch 2.10.0, but has ABI mismatch on Windows — Entry Point Not Found in xformers\_C.pyd)