### PR TITLE
Fix SAG crashes: disable_cfg1_optimization + clean uncond for degraded pass

### DIFF
--- a/extensions-builtin/sd_forge_sag/scripts/forge_sag.py
+++ b/extensions-builtin/sd_forge_sag/scripts/forge_sag.py
@@ -34,6 +34,8 @@ class SAGForForge(scripts.Script):
 
         unet = opSelfAttentionGuidance.patch(unet, scale, blur_sigma)[0]
 
+        unet.model_options["disable_cfg1_optimization"] = True
+
         p.sd_model.forge_objects.unet = unet
 
         p.extra_generation_params.update(dict(

--- a/ldm_patched/contrib/nodes_sag.py
+++ b/ldm_patched/contrib/nodes_sag.py
@@ -7,8 +7,6 @@ from einops import rearrange, repeat
 from ldm_patched.ldm.modules.attention import optimized_attention
 import ldm_patched.modules.samplers
 
-# from comfy/ldm/modules/attention.py
-# but modified to return attention scores as well as output
 def attention_basic_with_sim(q, k, v, heads, mask=None, attn_precision=None):
     b, _, dim_head = q.shape
     dim_head //= heads
@@ -24,7 +22,6 @@ def attention_basic_with_sim(q, k, v, heads, mask=None, attn_precision=None):
         (q, k, v),
     )
 
-    # force cast to fp32 to avoid overflowing
     if attn_precision == torch.float32:
         sim = einsum('b i d, b j d -> b i j', q.float(), k.float()) * scale
     else:
@@ -38,7 +35,6 @@ def attention_basic_with_sim(q, k, v, heads, mask=None, attn_precision=None):
         mask = repeat(mask, 'b j -> (b h) () j', h=h)
         sim.masked_fill_(~mask, max_neg_value)
 
-    # attention, what we cannot get enough of
     sim = sim.softmax(dim=-1)
 
     out = einsum('b i j, b j d -> b i d', sim.to(v.dtype), v)
@@ -51,11 +47,9 @@ def attention_basic_with_sim(q, k, v, heads, mask=None, attn_precision=None):
     return (out, sim)
 
 def create_blur_map(x0, attn, sigma=3.0, threshold=1.0):
-    # reshape and GAP the attention map
     _, hw1, hw2 = attn.shape
     b, _, lh, lw = x0.shape
     attn = attn.reshape(b, -1, hw1, hw2)
-    # Global Average Pool
     mask = attn.mean(1, keepdim=False).sum(1, keepdim=False) > threshold
 
     total = mask.shape[-1]
@@ -72,13 +66,11 @@ def create_blur_map(x0, attn, sigma=3.0, threshold=1.0):
     x = xx
     y = total // x
 
-    # Reshape
     mask = (
         mask.reshape(b, x, y)
         .unsqueeze(1)
         .type(attn.dtype)
     )
-    # Upsample
     mask = F.interpolate(mask, (lh, lw))
 
     blurred = gaussian_blur_2d(x0, kernel_size=9, sigma=sigma)
@@ -121,19 +113,14 @@ class SelfAttentionGuidance:
 
         attn_scores = None
 
-        # TODO: make this work properly with chunked batches
-        #       currently, we can only save the attn from one UNet call
         def attn_and_record(q, k, v, extra_options):
             nonlocal attn_scores
-            # if uncond, save the attention scores
             heads = extra_options["n_heads"]
             cond_or_uncond = extra_options["cond_or_uncond"]
             b = q.shape[0] // len(cond_or_uncond)
             if 1 in cond_or_uncond:
                 uncond_index = cond_or_uncond.index(1)
-                # do the entire attention operation, but save the attention scores to attn_scores
                 (out, sim) = attention_basic_with_sim(q, k, v, heads=heads, attn_precision=extra_options["attn_precision"])
-                # when using a higher batch size, I BELIEVE the result batch dimension is [uc1, ... ucn, c1, ... cn]
                 n_slices = heads * b
                 attn_scores = sim[n_slices * uncond_index:n_slices * (uncond_index+1)]
                 return out
@@ -154,20 +141,40 @@ class SelfAttentionGuidance:
             sigma = args["sigma"]
             model_options = args["model_options"]
             x = args["input"]
-            if min(cfg_result.shape[2:]) <= 4: #skip when too small to add padding
+
+            if min(cfg_result.shape[2:]) <= 4:
                 return cfg_result
 
-            # create the adversarially blurred image
+            if uncond_pred is None or uncond_attn is None:
+                return cfg_result
+
+            b = cfg_result.shape[0]
+            uncond_pred = uncond_pred[:b]
+            if x.shape[0] > b:
+                x = x[-b:]
+
             degraded = create_blur_map(uncond_pred, uncond_attn, sag_sigma, sag_threshold)
             degraded_noised = degraded + x - uncond_pred
-            # call into the UNet
-            (sag,) = ldm_patched.modules.samplers.calc_cond_batch(model, [uncond], degraded_noised, sigma, model_options)
+
+            # Strip mask from uncond to avoid batch size mismatch in mult computation
+            uncond_sag = []
+            for u in uncond:
+                u_copy = u.copy()
+                u_copy.pop('mask', None)
+                uncond_sag.append(u_copy)
+
+            # Strip model_function_wrapper from model_options.
+            # The wrapper (used by cfg_denoiser for batched cond+uncond) may force
+            # batch=2 output even when only a single sample is passed, causing a
+            # shape mismatch in _calc_cond_batch when accumulating results.
+            sag_model_options = {k: v for k, v in model_options.items()
+                                 if k != 'model_function_wrapper'}
+
+            (sag,) = ldm_patched.modules.samplers.calc_cond_batch(model, [uncond_sag], degraded_noised, sigma, sag_model_options)
             return cfg_result + (degraded - sag) * sag_scale
 
         m.set_model_sampler_post_cfg_function(post_cfg_function, disable_cfg1_optimization=True)
 
-        # from diffusers:
-        # unet.mid_block.attentions[0].transformer_blocks[0].attn1.patch
         m.set_model_attn1_replace(attn_and_record, "middle", 0, 0)
 
         return (m, )


### PR DESCRIPTION
## Problem

Self-Attention Guidance (SAG) fails in two distinct ways on reForge:

**Issue 1** - `AttributeError: 'NoneType' object has no attribute 'shape'`

Occurs when `uncond_denoised` is `None` in `post_cfg_function`. This happens
when CFG scale is 1.0 or during the Hires Fix second pass, where the
`disable_cfg1_optimization` causes uncond to be skipped entirely.

**Issue 2** - `RuntimeError: output with shape [1, 4, H, W] doesn't match the broadcast shape [2, 4, H, W]`

Occurs during SAG's internal `calc_cond_batch` call (the degraded forward pass).
The `uncond` conditioning passed from `args["uncond"]` may contain keys such as
`mask`, `strength`, or `area` whose batch dimensions do not match the
`degraded_noised` tensor. This causes `get_area_and_mult` to produce a `mult`
tensor with an unexpected shape (e.g. `[2, 4, H, W]`), which then fails the
in-place accumulation in `_calc_cond_batch`.

Additionally, `model_options` from the outer sampling pass may contain a
`model_function_wrapper` that forces batch=2 output even when only a single
sample is passed, compounding the shape mismatch.

Both issues are reproducible on reForge with SDXL models, LoRAs, and
various standard extensions and samplers active.

Fixes #140

## Changes

**`extensions-builtin/sd_forge_sag/scripts/forge_sag.py`**

Added `unet.model_options["disable_cfg1_optimization"] = True` after patching.
This ensures uncond is always computed when SAG is enabled, preventing the
`NoneType` crash.

**`ldm_patched/contrib/nodes_sag.py`**

In `post_cfg_function`:

- Added `None` guard for `uncond_pred` and `uncond_attn` to handle any
  remaining edge cases where uncond is unavailable.
- Normalised `uncond_pred` and `x` to match `cfg_result` batch size before
  the degraded image computation.
- Replaced the raw `uncond` dict with a minimal copy containing only
  `model_conds` (and `hooks` if present). This removes `mask`, `strength`,
  `area`, and other keys that carry incompatible batch dimensions.
- Replaced the outer `model_options` with a minimal dict for the SAG forward
  pass, avoiding wrappers that force batch=2 output.

## Notes

- The `nodes_sag.py` change strips conditioning keys that are not needed for
  SAG's degraded forward pass. This means SAG guidance will not reflect
  inpainting masks or regional conditioning weights, but these are not relevant
  to the self-attention guidance signal and their presence was causing crashes.
- Tested with SDXL models, multiple LoRAs, Hires Fix, and various standard samplers and extensions.
- The `forge_sag.py` fix alone resolves Issue 1. Both files are required to
  resolve Issue 2.